### PR TITLE
Cross-platform fixes, enable CI for Linux and MacOS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+# for details: http://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language: Cpp
+Standard: Cpp11
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 110
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+DerivePointerAlignment: false
+FixNamespaceComments: true
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+...

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,3 @@
+line_width: 110
+max_subgroups_hwrap: 30
+max_pargs_hwrap: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Test
         run: |
           cd build
-          ctest --output-on-failure --verbose
+          ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["releases/**"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  cpp-linux:
+    runs-on: ubuntu-latest
+    steps:
+      # Install CMake
+      - name: Install CMake, libelf, libdwarf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libelf-dev libdwarf-dev
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  cpp-windows:
+    runs-on: windows-latest
+    steps:
+      # Install CMake
+      - name: Install CMake
+        run: |
+          choco install cmake
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --config Release
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  cpp-macos:
+    runs-on: macos-latest
+    steps:
+      # Install CMake
+      - name: Install CMake
+        run: |
+          brew install cmake
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,27 +31,28 @@ jobs:
           cd build
           ctest --output-on-failure
 
-  cpp-windows:
-    runs-on: windows-latest
-    steps:
-      # Install CMake
-      - name: Install CMake
-        run: |
-          choco install cmake
-      # Clone the repository
-      - uses: actions/checkout@v4
-      # CMake configure and build
-      - name: Build
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build . --config Release
-      # Run tests
-      - name: Test
-        run: |
-          cd build
-          ctest --output-on-failure
+  # TODO(https://github.com/Verdant-Robotics/cbuf/issues/4): Fix Windows build
+  # cpp-windows:
+  #   runs-on: windows-latest
+  #   steps:
+  #     # Install CMake
+  #     - name: Install CMake
+  #       run: |
+  #         choco install cmake
+  #     # Clone the repository
+  #     - uses: actions/checkout@v4
+  #     # CMake configure and build
+  #     - name: Build
+  #       run: |
+  #         mkdir build
+  #         cd build
+  #         cmake ..
+  #         cmake --build . --config Release
+  #     # Run tests
+  #     - name: Test
+  #       run: |
+  #         cd build
+  #         ctest --output-on-failure
 
   cpp-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Test
         run: |
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ else()
     -Wextra \
     -Weverything \
     -Werror=return-type \
+    -Wno-unknown-warning-option \
     -Wno-c++98-compat \
     -Wno-c++98-compat-pedantic \
     -Wno-ctad-maybe-unsupported \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ include(AddTest)
 fetch_dependency(vlog "https://github.com/Verdant-Robotics/vlog.git" "main")
 # optional hjson package, if found it exposes more functionality on the CBufParser class
 fetch_dependency(hjson "https://github.com/Verdant-Robotics/hjson.git" "main")
-fetch_dependency(gtest "https://github.com/google/googletest.git" "8a6feabf04bec8fb125e0df0ad1195c42350725f")
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   add_compile_options(-march=x86-64-v3)
@@ -89,9 +88,21 @@ else()
 endif()
 
 set(CBUF_PARSE_SRCS
-    src/AstPrinter.cpp src/CPrinter.cpp src/FileData.cpp src/Lexer.cpp src/Parser.cpp src/Allocator.cpp
-    src/StringBuffer.cpp src/SymbolTable.cpp src/TextType.cpp src/Token.cpp src/CBufParser.cpp src/Interp.cpp
-    src/StdStringBuffer.cpp)
+    src/Allocator.cpp
+    src/AstPrinter.cpp
+    src/CBufParser.cpp
+    src/CPrinter.cpp
+    src/FileData.cpp
+    src/fileutils.cpp
+    src/Interp.cpp
+    src/Lexer.cpp
+    src/Parser.cpp
+    src/StdStringBuffer.cpp
+    src/StringBuffer.cpp
+    src/SymbolTable.cpp
+    src/TextType.cpp
+    src/Token.cpp
+)
 
 set(CBUF_SRCS src/cbuf.cpp)
 
@@ -121,7 +132,6 @@ endif()
 add_executable(cbuf ${CBUF_SRCS})
 target_include_directories(cbuf PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(cbuf PRIVATE cbuf_parse)
-target_link_libraries(cbuf PRIVATE stdc++fs)
 
 if(NOT TARGET cbuf_lib)
   add_library(cbuf_lib INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,6 @@ fetch_dependency(vlog "https://github.com/Verdant-Robotics/vlog.git" "main")
 # optional hjson package, if found it exposes more functionality on the CBufParser class
 fetch_dependency(hjson "https://github.com/Verdant-Robotics/hjson.git" "main")
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-  add_compile_options(-march=x86-64-v3)
-else()
-  add_compile_options(-mcpu=native)
-endif()
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ else()
   # TODO(jhurliman): Fix these warnings
   set(CMAKE_CXX_FLAGS
           "${CMAKE_CXX_FLAGS} \
-    -Wno-unaligned-access \
     -Wno-unused-parameter \
     -Wno-weak-vtables \
     -Wno-old-style-cast \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ else()
   # TODO(jhurliman): Fix these warnings
   set(CMAKE_CXX_FLAGS
           "${CMAKE_CXX_FLAGS} \
+    -Wno-unaligned-access \
     -Wno-unused-parameter \
     -Wno-weak-vtables \
     -Wno-old-style-cast \

--- a/cmake/FetchDependency.cmake
+++ b/cmake/FetchDependency.cmake
@@ -25,7 +25,7 @@ macro(fetch_dependency target url tag)
               PATHS ${PROJECT_SOURCE_DIR}/../${target} ${PROJECT_SOURCE_DIR}/../../${target}
                     ${PROJECT_SOURCE_DIR}/../../../${target} ${PROJECT_SOURCE_DIR}/../../../../${target})
     if(NOT ${target}_project)
-      FetchContent_Declare(${target} GIT_REPOSITORY ${url} GIT_TAG ${tag} GIT_SHALLOW TRUE)
+      FetchContent_Declare(${target} GIT_REPOSITORY ${url} GIT_TAG ${tag} GIT_SHALLOW FALSE)
       FetchContent_GetProperties(${target})
       if(NOT ${target}_POPULATED)
         execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Downloading ${target} ")

--- a/include/cbuf_preamble.h
+++ b/include/cbuf_preamble.h
@@ -5,17 +5,14 @@
 
 #define CBUF_MAGIC uint32_t(('V' << 24) | ('D' << 16) | ('N' << 8) | 'T')
 
-#ifndef ATTR_PACKED
-#define ATTR_PACKED __attribute__((__packed__))
-#endif
-
 ///
 /// Cbuf preamble stores 2 values on the size. On the top
 /// 4 bits, a 'variant' number is stored to differentiate
 /// messages of the same type.
 /// The lower 28 bits are the size of a packet
 ///
-struct ATTR_PACKED cbuf_preamble {
+#pragma pack(push, 1)
+struct cbuf_preamble {
   uint32_t magic = 0;
   uint32_t size_ = 0;
   uint64_t hash = 0;
@@ -67,6 +64,7 @@ struct ATTR_PACKED cbuf_preamble {
     }
   }
 };
+#pragma pack(pop)
 
 typedef void (*cbuf_metadata_fn)(const char* msg_meta, uint64_t hash, const char* msg_name, void* ctx);
 

--- a/include/cbuf_preamble.h
+++ b/include/cbuf_preamble.h
@@ -5,14 +5,17 @@
 
 #define CBUF_MAGIC uint32_t(('V' << 24) | ('D' << 16) | ('N' << 8) | 'T')
 
+#ifndef ATTR_PACKED
+#define ATTR_PACKED __attribute__((__packed__))
+#endif
+
 ///
 /// Cbuf preamble stores 2 values on the size. On the top
 /// 4 bits, a 'variant' number is stored to differentiate
 /// messages of the same type.
 /// The lower 28 bits are the size of a packet
 ///
-#pragma pack(push, 1)
-struct cbuf_preamble {
+struct ATTR_PACKED cbuf_preamble {
   uint32_t magic = 0;
   uint32_t size_ = 0;
   uint64_t hash = 0;
@@ -64,7 +67,6 @@ struct cbuf_preamble {
     }
   }
 };
-#pragma pack(pop)
 
 typedef void (*cbuf_metadata_fn)(const char* msg_meta, uint64_t hash, const char* msg_name, void* ctx);
 

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -228,7 +228,7 @@ static bool compute_hash(ast_struct* st, SymbolTable* symtable) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[%llu] ", elem->array_suffix->size);
+      buf.print("[" U64_FORMAT "] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);
@@ -503,7 +503,7 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
   PyType_Spec* spec = (PyType_Spec*)state->pool->alloc(sizeof(PyType_Spec));
   int str_size = strlen(st->name) + 8 + 5;
   char* type_name = (char*)state->pool->alloc(str_size);
-  snprintf(type_name, str_size, "pycbuf.%s_%llX", st->name, (hash & 0x0FFFFULL));
+  snprintf(type_name, str_size, "pycbuf.%s_" U64_FORMAT_HEX, st->name, (hash & 0x0FFFFULL));
   spec->name = type_name;
   spec->itemsize = 0;
   spec->flags = Py_TPFLAGS_DEFAULT;
@@ -587,8 +587,9 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->variant = pre->variant();
     pypre->type_name = st->name;
     pypre->source_name = source_cbuf_file_;
-    VLOG_ASSERT(pre->hash == hash, "Hash mismatch decoding type %s, expected %llX, got %llX", st->name, hash,
-                pre->hash);
+    VLOG_ASSERT(pre->hash == hash,
+                "Hash mismatch decoding type %s, expected " U64_FORMAT_HEX ", got " U64_FORMAT_HEX, st->name,
+                hash, pre->hash);
     u32 sizeof_preamble = sizeof(cbuf_preamble);  // 8 bytes hash, 4 bytes size
     buffer += sizeof_preamble;
     buf_size -= sizeof_preamble;
@@ -601,8 +602,8 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->magic = magic_;
   }
 
-  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p, hash: %llX", st->name, (void*)obj,
-             ((pycbuf_preamble*)obj)->hash);
+  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p, hash: " U64_FORMAT_HEX, st->name,
+             (void*)obj, ((pycbuf_preamble*)obj)->hash);
   VLOG_ASSERT(state->info_map->contains(((pycbuf_preamble*)obj)->hash));
 
   PyTypeInfo& pyInfo = (*state->info_map)[hash];

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -503,7 +503,7 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
   PyType_Spec* spec = (PyType_Spec*)state->pool->alloc(sizeof(PyType_Spec));
   int str_size = strlen(st->name) + 8 + 5;
   char* type_name = (char*)state->pool->alloc(str_size);
-  snprintf(type_name, str_size, "pycbuf.%s_" U64_FORMAT_HEX, st->name, (hash & 0x0FFFFULL));
+  snprintf(type_name, str_size, "pycbuf.%s_" U64_FORMAT_HEX, st->name, uint64_t((hash & 0x0FFFFULL)));
   spec->name = type_name;
   spec->itemsize = 0;
   spec->flags = Py_TPFLAGS_DEFAULT;

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -228,7 +228,7 @@ static bool compute_hash(ast_struct* st, SymbolTable* symtable) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[%lu] ", elem->array_suffix->size);
+      buf.print("[%llu] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);
@@ -587,7 +587,7 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->variant = pre->variant();
     pypre->type_name = st->name;
     pypre->source_name = source_cbuf_file_;
-    VLOG_ASSERT(pre->hash == hash, "Hash mismatch decoding type %s, expected %zX, got %zX", st->name, hash,
+    VLOG_ASSERT(pre->hash == hash, "Hash mismatch decoding type %s, expected %llX, got %llX", st->name, hash,
                 pre->hash);
     u32 sizeof_preamble = sizeof(cbuf_preamble);  // 8 bytes hash, 4 bytes size
     buffer += sizeof_preamble;
@@ -601,7 +601,7 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->magic = magic_;
   }
 
-  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p, hash: %zX", st->name, (void*)obj,
+  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p, hash: %llX", st->name, (void*)obj,
              ((pycbuf_preamble*)obj)->hash);
   VLOG_ASSERT(state->info_map->contains(((pycbuf_preamble*)obj)->hash));
 

--- a/pycbuf/CMakeLists.txt
+++ b/pycbuf/CMakeLists.txt
@@ -5,7 +5,7 @@ if(Python3_FOUND)
     add_library(pycbuf SHARED pycbuf.cpp CBufParserPy.cpp cbuf_reader_python.cpp)
     target_include_directories(pycbuf PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(pycbuf PUBLIC Python3::Module uloglib cbuf_internal)
-    target_compile_options(pycbuf PRIVATE -Wno-writable-strings -Wno-c99-designator -Wno-unused-function)
+    target_compile_options(pycbuf PRIVATE -Wno-unused-function)
     set_target_properties(pycbuf PROPERTIES PREFIX "")
 
     set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")

--- a/pycbuf/pycbuf.cpp
+++ b/pycbuf/pycbuf.cpp
@@ -580,6 +580,9 @@ static struct PyMemberDef pycbufreader_members[] = {
     {NULL, 0, 0, 0, NULL}  /* Sentinel */
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type"
+
 static struct PyMethodDef pycbufreader_methods[] = {
     {"__enter__",           (PyCFunction)                          pycbuf_cbufreader___enter___impl,         METH_NOARGS,                  pycbuf_cbufreader___enter_____doc__   },
     {"__exit__",            (PyCFunction)                          pycbuf_cbufreader___exit__,               METH_VARARGS | METH_KEYWORDS, pycbuf_cbufreader___exit_____doc__    },
@@ -596,6 +599,8 @@ static struct PyMethodDef pycbufreader_methods[] = {
     //
     {NULL,                  NULL,                                                                         0,                            NULL                                },  /* sentinel */
 };
+
+#pragma clang diagnostic pop
 
 static PyTypeObject PyCBufReader_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)

--- a/pycbuf/pycbuf.cpp
+++ b/pycbuf/pycbuf.cpp
@@ -611,8 +611,6 @@ static struct PyMethodDef pycbufreader_methods[] = {
 #pragma GCC diagnostic pop
 #endif
 
-// -Werror=missing-field-initializers
-
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
@@ -622,7 +620,7 @@ static struct PyMethodDef pycbufreader_methods[] = {
 #endif
 
 static PyTypeObject PyCBufReader_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base      = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = "pycbuf.CBufReader",
     .tp_basicsize = sizeof(cbufreader),
     .tp_dealloc   = (destructor) cbufreader_dealloc,
@@ -669,7 +667,7 @@ static struct PyMethodDef pycbufpreamble_methods[] = {
 #endif
 
 static PyTypeObject PyCBufPreamble_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base      = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = "pycbuf.CBufPreamble",
     .tp_basicsize = sizeof(pycbuf_preamble),
     .tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -769,8 +767,16 @@ static struct PyMethodDef pycbufmodule_methods[] = {
     {NULL, NULL, 0, NULL} /* sentinel */
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 static struct PyModuleDef PyCBuf_Module = {
-    PyModuleDef_HEAD_INIT,
+    .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "pycbuf",
     .m_doc = NULL,
     .m_size = sizeof(PyCBuf_State),
@@ -779,6 +785,12 @@ static struct PyModuleDef PyCBuf_Module = {
     .m_clear = pycbufmodule_clear,
     .m_free = (freefunc)pycbufmodule_free,
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 PyObject* pycbuf_getmodule(void) { return PyState_FindModule(&PyCBuf_Module); }
 

--- a/pycbuf/pycbuf.cpp
+++ b/pycbuf/pycbuf.cpp
@@ -611,6 +611,16 @@ static struct PyMethodDef pycbufreader_methods[] = {
 #pragma GCC diagnostic pop
 #endif
 
+// -Werror=missing-field-initializers
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 static PyTypeObject PyCBufReader_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = "pycbuf.CBufReader",
@@ -629,6 +639,12 @@ static PyTypeObject PyCBufReader_Type = {
     .tp_new       = pycbuf_cbufreader___new__,
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
+
 static struct PyMemberDef pycbufpreamble_members[] = {
     {"cbuf_magic", T_UINT, offsetof(pycbuf_preamble, magic), READONLY, NULL},
     {"cbuf_size", T_UINT, offsetof(pycbuf_preamble, size_), READONLY, NULL},
@@ -644,6 +660,14 @@ static struct PyMethodDef pycbufpreamble_methods[] = {
     {NULL, NULL, 0, NULL}  /* sentinel */
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 static PyTypeObject PyCBufPreamble_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = "pycbuf.CBufPreamble",
@@ -653,6 +677,12 @@ static PyTypeObject PyCBufPreamble_Type = {
     .tp_members   = pycbufpreamble_members,
     .tp_new       = PyType_GenericNew,
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 // clang-format on
 

--- a/pycbuf/pycbuf.cpp
+++ b/pycbuf/pycbuf.cpp
@@ -354,8 +354,8 @@ static PyObject* pycbuf_cbufreader_get_counts(PyObject* self) {
 
 static int pycbuf_cbufreader___init__(PyObject* self, PyObject* args, PyObject* kwargs) {
   int return_value = -1;
-  static char* keywords[] = {"ulog_path",  "source_filter", "role_filter",  "message_filter",
-                             "early_time", "late_time",     "try_recovery", NULL};
+  static const char* keywords[] = {"ulog_path",  "source_filter", "role_filter",  "message_filter",
+                                   "early_time", "late_time",     "try_recovery", NULL};
   char* ulogpath = nullptr;
   PyObject* rfilters = nullptr;
   PyObject* sfilters = nullptr;
@@ -459,7 +459,7 @@ static PyObject* pycbuf_cbufreader___exit___impl(cbufreader* self, PyObject* exc
 
 static PyObject* pycbuf_cbufreader___exit__(PyObject* self, PyObject* args, PyObject* kwargs) {
   PyObject* return_value = NULL;
-  char* keywords[] = {"exc_type", "exc_value", "traceback", nullptr};
+  const char* keywords[] = {"exc_type", "exc_value", "traceback", nullptr};
 
   PyObject* exc_type = Py_None;
   PyObject* exc_value = Py_None;
@@ -580,8 +580,13 @@ static struct PyMemberDef pycbufreader_members[] = {
     {NULL, 0, 0, 0, NULL}  /* Sentinel */
 };
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 
 static struct PyMethodDef pycbufreader_methods[] = {
     {"__enter__",           (PyCFunction)                          pycbuf_cbufreader___enter___impl,         METH_NOARGS,                  pycbuf_cbufreader___enter_____doc__   },
@@ -600,7 +605,11 @@ static struct PyMethodDef pycbufreader_methods[] = {
     {NULL,                  NULL,                                                                         0,                            NULL                                },  /* sentinel */
 };
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 static PyTypeObject PyCBufReader_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)

--- a/src/AstPrinter.cpp
+++ b/src/AstPrinter.cpp
@@ -29,7 +29,7 @@ AstPrinter::~AstPrinter() {}
 static void PrintAstValue(const ast_value* val, StdStringBuffer* buffer) {
   switch (val->valtype) {
     case VALTYPE_INTEGER:
-      buffer->print_no("%zd", val->int_val);
+      buffer->print_no("%zd", ssize_t(val->int_val));
       break;
     case VALTYPE_FLOAT:
       buffer->print_no("%f", val->float_val);
@@ -105,7 +105,7 @@ void AstPrinter::print_elem(ast_element* elem) {
 
   while (ar != nullptr) {
     if (ar->size != 0)
-      buffer->print_no("[%ld]", ar->size);
+      buffer->print_no("[%llu]", ar->size);
     else
       buffer->print_no("[]");
     ar = ar->next;
@@ -125,7 +125,7 @@ void AstPrinter::print_enum(ast_enum* enm) {
   buffer->increase_ident();
   for (auto& el : enm->elements) {
     if (el.item_assigned) {
-      buffer->print("%s = %zd,\n", el.item_name, el.item_value);
+      buffer->print("%s = %zd,\n", el.item_name, ssize_t(el.item_value));
     } else {
       buffer->print("%s,\n", el.item_name);
     }

--- a/src/AstPrinter.cpp
+++ b/src/AstPrinter.cpp
@@ -105,7 +105,7 @@ void AstPrinter::print_elem(ast_element* elem) {
 
   while (ar != nullptr) {
     if (ar->size != 0)
-      buffer->print_no("[%llu]", ar->size);
+      buffer->print_no("[" U64_FORMAT "]", ar->size);
     else
       buffer->print_no("[]");
     ar = ar->next;

--- a/src/CBufParser.cpp
+++ b/src/CBufParser.cpp
@@ -599,14 +599,12 @@ bool process_element_conversion(const ast_element* elem, const u8*& bin_buffer, 
   u32 dst_array_size = 0;
   bool check_dst_array = false;
   u8* dst_elem_buf = dst_buf;
-  u32 dst_elem_size = dst_size;
 
   if (dst_elem->array_suffix) {
     if (dst_elem->is_compact_array) {
       // For compact arrays, write the num
       *(u32*)dst_elem_buf = array_size;
       dst_elem_buf += sizeof(array_size);
-      dst_elem_size -= sizeof(array_size);
     }
     if (!dst_elem->is_dynamic_array) {
       check_dst_array = true;
@@ -688,7 +686,6 @@ bool process_element_conversion(const ast_element* elem, const u8*& bin_buffer, 
       }
     }
     dst_elem_buf += dst_elem->typesize;
-    dst_elem_size -= dst_elem->typesize;
   }
 
   return true;
@@ -790,18 +787,15 @@ bool convert_element_string(const ast_element* elem, const u8*& bin_buffer, size
   u32 dst_array_size = 0;
   bool check_dst_array = false;
   u8* dst_elem_buf = dst_buf;
-  u32 dst_elem_size = dst_size;
 
   if (elem->array_suffix) {
     if (dst_elem->is_compact_array) {
       // For compact arrays, write the num
       *(u32*)dst_elem_buf = array_size;
       dst_elem_buf += sizeof(array_size);
-      dst_elem_size -= sizeof(array_size);
     }
     if (!dst_elem->is_dynamic_array) {
       check_dst_array = true;
-      dst_array_size = dst_elem->array_suffix->size;
     }
   }
 
@@ -844,7 +838,6 @@ bool convert_element_string(const ast_element* elem, const u8*& bin_buffer, size
         return false;
     }
     dst_elem_buf += dst_elem->typesize;
-    dst_elem_size -= dst_elem->typesize;
   }
 
   return true;
@@ -918,18 +911,15 @@ bool convert_element_short_string(const ast_element* elem, const u8*& bin_buffer
   u32 dst_array_size = 0;
   bool check_dst_array = false;
   u8* dst_elem_buf = dst_buf;
-  u32 dst_elem_size = dst_size;
 
   if (elem->array_suffix) {
     if (dst_elem->is_compact_array) {
       // For compact arrays, write the num
       *(u32*)dst_elem_buf = array_size;
       dst_elem_buf += sizeof(array_size);
-      dst_elem_size -= sizeof(array_size);
     }
     if (!dst_elem->is_dynamic_array) {
       check_dst_array = true;
-      dst_array_size = dst_elem->array_suffix->size;
     }
   }
 
@@ -968,7 +958,6 @@ bool convert_element_short_string(const ast_element* elem, const u8*& bin_buffer
         return false;
     }
     dst_elem_buf += dst_elem->typesize;
-    dst_elem_size -= dst_elem->typesize;
   }
 
   return true;

--- a/src/CBufParser.cpp
+++ b/src/CBufParser.cpp
@@ -1085,7 +1085,7 @@ bool compute_hash(ast_struct* st, SymbolTable* symtable, Interp* interp) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[%llu] ", elem->array_suffix->size);
+      buf.print("[" U64_FORMAT "] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);

--- a/src/CBufParser.cpp
+++ b/src/CBufParser.cpp
@@ -1096,7 +1096,7 @@ bool compute_hash(ast_struct* st, SymbolTable* symtable, Interp* interp) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[%lu] ", elem->array_suffix->size);
+      buf.print("[%llu] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -609,7 +609,8 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
-  buffer->print("struct ATTR_PACKED %s {\n", st->name);
+  buffer->print("#pragma pack(push, 1)\n");
+  buffer->print("struct %s {\n", st->name);
   buffer->increase_ident();
 
   if (st->naked) {
@@ -784,6 +785,7 @@ void CPrinter::print(ast_struct* st) {
                 buf.get_buffer());
   buffer->decrease_ident();
   buffer->print("};\n");
+  buffer->print("#pragma pack(pop)\n\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -609,8 +609,7 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
-  buffer->print("#pragma pack(push, 1)\n");
-  buffer->print("struct %s {\n", st->name);
+  buffer->print("struct ATTR_PACKED %s {\n", st->name);
   buffer->increase_ident();
 
   if (st->naked) {
@@ -785,7 +784,6 @@ void CPrinter::print(ast_struct* st) {
                 buf.get_buffer());
   buffer->decrease_ident();
   buffer->print("};\n");
-  buffer->print("#pragma pack(pop)\n\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -7,6 +7,7 @@
 #include "AstPrinter.h"
 #include "FileData.h"
 #include "ast.h"
+#include "fileutils.h"
 
 // clang-format off
 static const char* ElementTypeToStrC[] = {
@@ -1241,23 +1242,21 @@ void CPrinter::printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<con
 
   buffer->print("%s : %s ", outfile, c_name);
   for (int i = 0; i < top_ast->imported_files.size(); i++) {
-    char* p = canonicalize_file_name(top_ast->imported_files[i]);
-    if (p == nullptr) {
+    std::string p = getCanonicalPath(top_ast->imported_files[i]);
+    if (p.empty()) {
       // we could not find an imported file, search on include paths
       char ipbuf[512];
       for (int ip = 0; ip < incs.size(); ip++) {
         snprintf(ipbuf, sizeof(ipbuf), "%s/%s", incs[ip], top_ast->imported_files[i]);
-        p = canonicalize_file_name(ipbuf);
-        if (p != nullptr) break;
+        p = getCanonicalPath(ipbuf);
+        if (!p.empty()) break;
       }
-      if (p == nullptr) {
+      if (p.empty()) {
         fprintf(stderr, "Include file %s could not be found!\n", top_ast->imported_files[i]);
         exit(-1);
       }
     }
-    buffer->print("\\\n  %s ", p);
-    free(p);
-    p = nullptr;
+    buffer->print("\\\n  %s ", p.c_str());
   }
   buffer->print("\n");
 }

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -593,9 +593,6 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
-  buffer->print("#pragma GCC diagnostic push\n");
-  buffer->print("#pragma GCC diagnostic ignored \"-Wunaligned-access\"\n");
-
   buffer->print("struct ATTR_PACKED %s {\n", st->name);
   buffer->increase_ident();
 
@@ -771,8 +768,6 @@ void CPrinter::print(ast_struct* st) {
                 buf.get_buffer());
   buffer->decrease_ident();
   buffer->print("};\n\n");
-
-  buffer->print("#pragma GCC diagnostic pop\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -94,6 +94,16 @@ void CPrinter::print(ast_const* cst) {
 }
 
 void CPrinter::print(ast_namespace* sp) {
+  // Emit GCC and clang pragmas to disable -Wpacked
+  buffer->print("#if defined(__GNUC__)\n");
+  buffer->print("#pragma GCC diagnostic push\n");
+  buffer->print("#pragma GCC diagnostic ignored \"-Wpacked\"\n");
+  buffer->print("#pragma GCC diagnostic ignored \"-Wunaligned-access\"\n");
+  buffer->print("#elif defined(__clang__)\n");
+  buffer->print("#pragma clang diagnostic push\n");
+  buffer->print("#pragma clang diagnostic ignored \"-Wpacked\"\n");
+  buffer->print("#endif\n\n");
+
   buffer->print("namespace %s {\n", sp->name);
   buffer->increase_ident();
 
@@ -115,6 +125,13 @@ void CPrinter::print(ast_namespace* sp) {
 
   buffer->decrease_ident();
   buffer->print("};\n\n");
+
+  // Emit GCC and clang pragmas to re-enable -Wpacked
+  buffer->print("#if defined(__GNUC__)\n");
+  buffer->print("#pragma GCC diagnostic pop\n");
+  buffer->print("#elif defined(__clang__)\n");
+  buffer->print("#pragma clang diagnostic pop\n");
+  buffer->print("#endif\n\n");
 }
 
 void CPrinter::helper_print_array_suffix(ast_element* elem) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -593,8 +593,8 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
-  buffer->print("#pragma clang diagnostic push\n");
-  buffer->print("#pragma clang diagnostic ignored \"-Wunaligned-access\"\n");
+  buffer->print("#pragma GCC diagnostic push\n");
+  buffer->print("#pragma GCC diagnostic ignored \"-Wunaligned-access\"\n");
 
   buffer->print("struct ATTR_PACKED %s {\n", st->name);
   buffer->increase_ident();
@@ -772,7 +772,7 @@ void CPrinter::print(ast_struct* st) {
   buffer->decrease_ident();
   buffer->print("};\n\n");
 
-  buffer->print("#pragma clang diagnostic pop\n");
+  buffer->print("#pragma GCC diagnostic pop\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -95,13 +95,12 @@ void CPrinter::print(ast_const* cst) {
 
 void CPrinter::print(ast_namespace* sp) {
   // Emit GCC and clang pragmas to disable -Wpacked
-  buffer->print("#if defined(__GNUC__)\n");
+  buffer->print("#if defined(__clang__)\n");
+  buffer->print("#pragma clang diagnostic push\n");
+  buffer->print("#pragma clang diagnostic ignored \"-Wunaligned-access\"\n");
+  buffer->print("#elif defined(__GNUC__)\n");
   buffer->print("#pragma GCC diagnostic push\n");
   buffer->print("#pragma GCC diagnostic ignored \"-Wpacked\"\n");
-  buffer->print("#pragma GCC diagnostic ignored \"-Wunaligned-access\"\n");
-  buffer->print("#elif defined(__clang__)\n");
-  buffer->print("#pragma clang diagnostic push\n");
-  buffer->print("#pragma clang diagnostic ignored \"-Wpacked\"\n");
   buffer->print("#endif\n\n");
 
   buffer->print("namespace %s {\n", sp->name);
@@ -127,10 +126,10 @@ void CPrinter::print(ast_namespace* sp) {
   buffer->print("};\n\n");
 
   // Emit GCC and clang pragmas to re-enable -Wpacked
-  buffer->print("#if defined(__GNUC__)\n");
-  buffer->print("#pragma GCC diagnostic pop\n");
-  buffer->print("#elif defined(__clang__)\n");
+  buffer->print("#if defined(__clang__)\n");
   buffer->print("#pragma clang diagnostic pop\n");
+  buffer->print("#elif defined(__GNUC__)\n");
+  buffer->print("#pragma GCC diagnostic pop\n");
   buffer->print("#endif\n\n");
 }
 

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -128,7 +128,7 @@ void CPrinter::helper_print_array_suffix(ast_element* elem) {
                   elem->name);
   } else {
     // plain simple static array
-    buffer->print_no(" %llu;\n", elem->array_suffix->size);
+    buffer->print_no(" " U64_FORMAT ";\n", elem->array_suffix->size);
   }
 }
 
@@ -174,7 +174,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("ret_size += sizeof(uint32_t); // Encode the length of %s in the var num_%s\n",
                           elem->name, elem->name);
           } else {
-            buffer->print("uint32_t num_%s = %llu;\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
           }
           // No need to encode elements on the static array case, we know them already
           buffer->print("for(int %s_index=0; %s_index < int(num_%s); %s_index++) {\n", elem->name, elem->name,
@@ -296,7 +296,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("*reinterpret_cast<uint32_t *>(data) = num_%s;\n", elem->name);
             buffer->print("data += sizeof(uint32_t);\n");
           } else {
-            buffer->print("uint32_t num_%s = %llu;\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
           }  // No need to encode the number of elements on the static array case, we know them already
           buffer->print("for(size_t %s_index=0; %s_index < num_%s; %s_index++) {\n", elem->name, elem->name,
                         elem->name, elem->name);
@@ -479,7 +479,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("num_%s = *reinterpret_cast<uint32_t *>(data);\n", elem->name);
             buffer->print("data += sizeof(uint32_t);\n");
           } else {  // No need to decode the number of elements on the static array case, we know them already
-            buffer->print("uint32_t num_%s = %llu;\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
           }
           buffer->print("for(uint32_t i=0; i<num_%s; i++) {\n", elem->name);
           buffer->increase_ident();
@@ -514,7 +514,7 @@ void CPrinter::print_net(ast_struct* st) {
         } else {
           buffer->print("memcpy(this->%s, data, %d*sizeof(int32_t));\n", elem->name,
                         (int)elem->array_suffix->size);
-          buffer->print("data += %llu*sizeof(int32_t);\n", elem->array_suffix->size);
+          buffer->print("data += " U64_FORMAT "*sizeof(int32_t);\n", elem->array_suffix->size);
         }
       } else if (elem->type == TYPE_CUSTOM) {
         if (elem->is_dynamic_array) {
@@ -536,7 +536,8 @@ void CPrinter::print_net(ast_struct* st) {
         } else {  // @warning: what happens here when the encode net size is not the same on each elem?
           buffer->print("memcpy(this->%s, data, %d*this->%s[0].encode_net_size());\n", elem->name,
                         (int)elem->array_suffix->size, elem->name);
-          buffer->print("data += %llu*this->%s[0].encode_net_size();\n", elem->array_suffix->size, elem->name);
+          buffer->print("data += " U64_FORMAT "*this->%s[0].encode_net_size();\n", elem->array_suffix->size,
+                        elem->name);
         }
       } else {
         assert(elem->type == TYPE_STRING);
@@ -803,8 +804,8 @@ void CPrinter::printInit(ast_element* elem) {
     buffer->print("%s.clear();\n", elem->name);
   } else if (ar && (ar->size > 0)) {
     // static arrays (compact and not too)
-    buffer->print("for(int %s_index = 0; %s_index < %zu; %s_index++) {\n", elem->name, elem->name, size_t(ar->size),
-                  elem->name);
+    buffer->print("for(int %s_index = 0; %s_index < %zu; %s_index++) {\n", elem->name, elem->name,
+                  size_t(ar->size), elem->name);
     buffer->increase_ident();
     buffer->print("%s[%s_index]", elem->name, elem->name);
     if (struct_type(elem, sym)) {
@@ -891,7 +892,7 @@ void CPrinter::print(ast_element* elem) {
   }
   buffer->print("%s", elem->name);
   while (ar != nullptr) {
-    if (ar->size != 0) buffer->print("[%llu]", ar->size);
+    if (ar->size != 0) buffer->print("[" U64_FORMAT "]", ar->size);
     ar = ar->next;
   }
   if (elem->init_value != nullptr) {
@@ -996,7 +997,7 @@ void CPrinter::printLoader(ast_element* elem) {
                     elem->name, elem->name);
     } else {
       buffer->print("if (!json[\"%s\"].defined()) break;\n", elem->name);
-      buffer->print("uint32_t num_%s = %llu;\n", elem->name, elem->array_suffix->size);
+      buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
       buffer->print("for( int %s_index=0; %s_index < num_%s; %s_index++) {\n", elem->name, elem->name,
                     elem->name, elem->name);
     }

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -591,6 +591,9 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
+  buffer->print("#pragma clang diagnostic push\n");
+  buffer->print("#pragma clang diagnostic ignored \"-Wunaligned-access\"\n");
+
   buffer->print("struct ATTR_PACKED %s {\n", st->name);
   buffer->increase_ident();
 
@@ -766,6 +769,8 @@ void CPrinter::print(ast_struct* st) {
                 buf.get_buffer());
   buffer->decrease_ident();
   buffer->print("};\n\n");
+
+  buffer->print("#pragma clang diagnostic pop\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -609,7 +609,8 @@ void CPrinter::print_net(ast_struct* st) {
 void CPrinter::print(ast_struct* st) {
   if (st->file != main_file) return;
 
-  buffer->print("struct ATTR_PACKED %s {\n", st->name);
+  buffer->print("#pragma pack(push, 1)\n");
+  buffer->print("struct %s {\n", st->name);
   buffer->increase_ident();
 
   if (st->naked) {
@@ -783,7 +784,8 @@ void CPrinter::print(ast_struct* st) {
   buffer->print("static constexpr const char * cbuf_string = R\"CBUF_CODE(\n%s)CBUF_CODE\";\n\n",
                 buf.get_buffer());
   buffer->decrease_ident();
-  buffer->print("};\n\n");
+  buffer->print("};\n");
+  buffer->print("#pragma pack(pop)\n\n");
 }
 
 void CPrinter::print(ast_enum* en) {

--- a/src/cbuf.cpp
+++ b/src/cbuf.cpp
@@ -7,6 +7,7 @@
 #include "Parser.h"
 #include "SymbolTable.h"
 #include "computefuncs.h"
+#include "fileutils.h"
 
 const char* get_str_for_elem_type(ElementType t);
 
@@ -187,17 +188,16 @@ int main(int argc, char** argv) {
   }
 
   if (args.depfile != nullptr) {
-    char *optr = nullptr, *cptr = nullptr;
     StdStringBuffer deptext;
 
     if (args.outfile == nullptr) {
       fprintf(stderr, "Please provide an outfile when using depfiles\n");
       return -1;
     }
-    cptr = canonicalize_file_name(args.srcfile);
-    optr = canonicalize_file_name(args.outfile);
+    const std::string srcFile = getCanonicalPath(args.srcfile);
+    const std::string dstFile = getCanonicalPath(args.outfile);
 
-    printer.printDepfile(&deptext, top_ast, args.incs, cptr, optr);
+    printer.printDepfile(&deptext, top_ast, args.incs, srcFile.c_str(), dstFile.c_str());
     FILE* f = fopen(args.depfile, "w");
     if (f == nullptr) {
       fprintf(stderr, "File %s could not be opened for writing\n", args.depfile);
@@ -205,8 +205,6 @@ int main(int argc, char** argv) {
     }
     fprintf(f, "%s", deptext.get_buffer());
     fclose(f);
-    free(cptr);
-    free(optr);
   }
 
   return 0;

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -1,0 +1,29 @@
+#include <string>
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <limits.h>
+#include <stdlib.h>
+#endif
+
+#include "fileutils.h"
+
+std::string getCanonicalPath(const char *path) {
+#if defined(_WIN32)
+  char buffer[MAX_PATH];
+  if (GetFullPathName(path, MAX_PATH, buffer, nullptr)) {
+    return std::string(buffer);
+  } else {
+    return std::string();
+  }
+#else
+  char *realPath = realpath(path, nullptr);
+  if (realPath) {
+    std::string canonicalPath(realPath);
+    free(realPath);
+    return canonicalPath;
+  } else {
+    return std::string();
+  }
+#endif
+}

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+/**
+ * @brief Returns the canonical path of the given path. Similar to the
+ *   `canonicalize_file_name()` GNU extension on Linux.
+ * @param path The path to canonicalize.
+ * @returns The canonical path of the given path on success, or an empty string
+ *   on failure.
+ */
+std::string getCanonicalPath(const char *path);

--- a/src/mytypes.h
+++ b/src/mytypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <climits>
+#include <cinttypes>
 #include <inttypes.h>
 #include <stdint.h>
 
@@ -14,15 +14,8 @@
 #define PLATFORM_POSIX
 #endif
 
-#if UINT64_MAX == ULLONG_MAX
-#define U64_FORMAT "%llu"
-#define U64_FORMAT_HEX "%llX"
-#elif UINT64_MAX == ULONG_MAX
-#define U64_FORMAT "%lu"
-#define U64_FORMAT_HEX "%lX"
-#else
-#error "uint64_t is not supported"
-#endif
+#define U64_FORMAT "%" PRIu64
+#define U64_FORMAT_HEX "%" PRIX64
 
 typedef signed char s8;
 typedef signed short s16;
@@ -36,10 +29,6 @@ typedef int64_t s64;
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
-#if defined(PLATFORM_WINDOWS)
-typedef unsigned long long u64;
-#else
 typedef uint64_t u64;
-#endif
 typedef float f32;
 typedef double f64;

--- a/src/mytypes.h
+++ b/src/mytypes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <climits>
 #include <inttypes.h>
 #include <stdint.h>
 
@@ -11,6 +12,16 @@
 #elif defined(__APPLE__)
 #define PLATFORM_MACOS
 #define PLATFORM_POSIX
+#endif
+
+#if UINT64_MAX == ULLONG_MAX
+#define U64_FORMAT "%llu"
+#define U64_FORMAT_HEX "%llX"
+#elif UINT64_MAX == ULONG_MAX
+#define U64_FORMAT "%lu"
+#define U64_FORMAT_HEX "%lX"
+#else
+#error "uint64_t is not supported"
 #endif
 
 typedef signed char s8;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required(VERSION 3.13.0)
 
 include(BuildCbuf)
+include(FetchDependency)
+
+fetch_dependency(gtest "https://github.com/google/googletest.git" "8a6feabf04bec8fb125e0df0ad1195c42350725f")
 
 build_cbuf(NAME test_cbuf_samples MSG_FILES samples/image.cbuf samples/inctype.cbuf)
 
 add_executable(test_main test_main.cpp test_utils.cpp samples/image.h samples/inctype.h)
-target_link_libraries(test_main test_cbuf_samples cbuf_lib uloglib stdc++fs)
+target_link_libraries(test_main test_cbuf_samples cbuf_lib uloglib)
 target_include_directories(test_main PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/samples)
 add_unit_test(NAME test_main COMMAND test_main)
 
 add_executable(test_ulogger test_ulogger.cpp samples/image.h)
-target_link_libraries(test_ulogger gtest test_cbuf_samples cbuf_lib uloglib stdc++fs gtest)
+target_link_libraries(test_ulogger gtest test_cbuf_samples cbuf_lib uloglib gtest)
 target_include_directories(test_ulogger PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/samples)
 add_unit_test(NAME test_ulogger COMMAND test_ulogger)
 

--- a/test/hjson_helper.cpp
+++ b/test/hjson_helper.cpp
@@ -4,6 +4,8 @@
 #include <math.h>
 #include <string.h>
 
+#include <cmath>
+
 bool has_member(const Hjson::Value& doc, const std::string& objName) {
   auto v = doc[objName];
   if (!v.defined()) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -29,7 +29,7 @@ void test_serialize() {
   messages::image img, img2;
   bool ret;
   set_data(img, 13);
-  const char* test_filename = std::tmpnam("test_file.cb");
+  const char* test_filename = std::tmpnam(nullptr);
 
   remove(test_filename);
 

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -3,6 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <cstdio>
+
 #include "assert.h"
 #include "cbuf_stream.h"
 #include "image.h"
@@ -27,7 +29,7 @@ void test_serialize() {
   messages::image img, img2;
   bool ret;
   set_data(img, 13);
-  const char* test_filename = "test_file.ulog";
+  const char* test_filename = std::tmpnam("test_file.cb");
 
   remove(test_filename);
 

--- a/test/test_parsing.cpp
+++ b/test/test_parsing.cpp
@@ -12,6 +12,8 @@
 #include "image.h" 
 #include "image_json.h"
 
+#if defined(HJSON_PRESENT)
+
 // Test FillHjson method. 
 TEST(HJsonParsing, Simple) {
   messages::image img1;
@@ -60,6 +62,8 @@ TEST(HJsonParsing, Complex) {
       }
   */
 }
+
+#endif
 
 TEST(JStrParsing, Simple) {
   messages::image img1;

--- a/test/test_ulogger.cpp
+++ b/test/test_ulogger.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include <chrono>
+#include <filesystem>
 #include <thread>
 
 #include "cbuf_stream.h"
@@ -9,14 +10,7 @@
 #include "inctype.h"
 #include "ulogger.h"
 
-#if (defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE > 7)) || \
-    (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION > 10000))
-#include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 void set_data(messages::image& img, unsigned seed) {
   srand(seed);

--- a/ulog/CMakeLists.txt
+++ b/ulog/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(cbuf_stream PUBLIC meta_cbuf cbuf_lib cbuf_parse_dynamic p
 # Class using templates to have callbacks as we read messages
 add_library(uloglib SHARED src/ulogger.cpp src/cbuf_readerbase.cpp src/cbuf_reader.cpp)
 target_include_directories(uloglib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(uloglib PUBLIC cbuf_stream vlog stdc++fs)
+target_link_libraries(uloglib PUBLIC cbuf_stream vlog)
 
 add_library(ringbufferlib INTERFACE)
 target_include_directories(ringbufferlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/ulog/CMakeLists.txt
+++ b/ulog/CMakeLists.txt
@@ -8,7 +8,7 @@ build_cbuf(NAME meta_cbuf MSG_FILES cbufmsg/metadata.cbuf)
 add_library(cbuf_stream SHARED src/cbuf_stream.cpp)
 target_include_directories(cbuf_stream PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(cbuf_stream PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/cbufmsg)
-target_link_libraries(cbuf_stream PUBLIC meta_cbuf cbuf_lib cbuf_parse_dynamic pthread)
+target_link_libraries(cbuf_stream PUBLIC meta_cbuf cbuf_lib cbuf_parse_dynamic vlog pthread)
 
 # uloglib is a library for handling ulogger, how we create logs, and cbufreader, the C++
 # Class using templates to have callbacks as we read messages

--- a/ulog/include/cbuf_reader.h
+++ b/ulog/include/cbuf_reader.h
@@ -2,6 +2,7 @@
 
 #include <hjson.h>
 
+#include <filesystem>
 #include <functional>
 #include <optional>
 #include <set>
@@ -11,14 +12,7 @@
 #include "cbuf_readerbase.h"
 #include "vlog.h"
 
-#if (defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE > 7)) || \
-    (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION > 10000))
-#include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 template <typename T>
 void loadFromJson(const Hjson::Value& json, T& obj);

--- a/ulog/include/ulogger.h
+++ b/ulog/include/ulogger.h
@@ -114,7 +114,7 @@ public:
 
     cbuf_preamble* pre = &member->preamble;
     VLOG_ASSERT(pre->magic == CBUF_MAGIC, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
-    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %lX, but it is %lX", member->hash(),
+    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %llX, but it is %llX", member->hash(),
                 pre->hash);
     VLOG_ASSERT(pre->size() != 0);
 
@@ -138,7 +138,7 @@ public:
     // Check again
     pre = (cbuf_preamble*)ringbuffer_mem;
     VLOG_ASSERT(pre->magic == CBUF_MAGIC, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
-    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %lX, but it is %lX", member->hash(),
+    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %llX, but it is %llX", member->hash(),
                 pre->hash);
     VLOG_ASSERT(pre->size() != 0);
 

--- a/ulog/include/ulogger.h
+++ b/ulog/include/ulogger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <climits>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -11,6 +12,16 @@
 #include "cbuf_stream.h"
 #include "ringbuffer.h"
 #include "vlog.h"
+
+#if UINT64_MAX == ULLONG_MAX
+#define U64_FORMAT "%llu"
+#define U64_FORMAT_HEX "%llX"
+#elif UINT64_MAX == ULONG_MAX
+#define U64_FORMAT "%lu"
+#define U64_FORMAT_HEX "%lX"
+#else
+#error "uint64_t is not supported"
+#endif
 
 // Ulogger is a singleton class to log to a file, using cbuf serialization.
 // Example usage:
@@ -114,7 +125,8 @@ public:
 
     cbuf_preamble* pre = &member->preamble;
     VLOG_ASSERT(pre->magic == CBUF_MAGIC, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
-    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %llX, but it is %llX", member->hash(),
+    VLOG_ASSERT(pre->hash == member->hash(),
+                "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
                 pre->hash);
     VLOG_ASSERT(pre->size() != 0);
 
@@ -138,7 +150,8 @@ public:
     // Check again
     pre = (cbuf_preamble*)ringbuffer_mem;
     VLOG_ASSERT(pre->magic == CBUF_MAGIC, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
-    VLOG_ASSERT(pre->hash == member->hash(), "Expected hash to be %llX, but it is %llX", member->hash(),
+    VLOG_ASSERT(pre->hash == member->hash(),
+                "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
                 pre->hash);
     VLOG_ASSERT(pre->size() != 0);
 

--- a/ulog/include/ulogger.h
+++ b/ulog/include/ulogger.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vlog.h>
+
 #include <atomic>
 #include <cinttypes>
 #include <climits>
@@ -118,17 +120,16 @@ public:
 
     cbuf_preamble* pre = &member->preamble;
     if (pre->magic != CBUF_MAGIC) {
-      // VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
+      VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
       return false;
     }
     if (pre->hash != member->hash()) {
-      // VLOG_ASSERT(false,
-      //             "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
-      //             pre->hash);
+      VLOG_ASSERT(false, "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
+                  pre->hash);
       return false;
     }
     if (pre->size() == 0) {
-      // VLOG_ASSERT(false, "Expected size to be non-zero");
+      VLOG_ASSERT(false, "Expected size to be non-zero");
       return false;
     }
 
@@ -138,13 +139,13 @@ public:
     if (member->supports_compact()) {
       if (!member->encode_net(ringbuffer_mem, stsize)) {
         ringbuffer.populate(buffer_handle);
-        // VLOG_ASSERT(false, "Encode net failed for message : %s ", member->TYPE_STRING);
+        VLOG_ASSERT(false, "Encode net failed for message : %s ", member->TYPE_STRING);
         return false;
       }
     } else {
       if (!member->encode(ringbuffer_mem, stsize)) {
         ringbuffer.populate(buffer_handle);
-        // VLOG_ASSERT(false, "Encode failed for message : %s ", member->TYPE_STRING);
+        VLOG_ASSERT(false, "Encode failed for message : %s ", member->TYPE_STRING);
         return false;
       }
     }
@@ -152,17 +153,16 @@ public:
     // Check again
     pre = (cbuf_preamble*)ringbuffer_mem;
     if (pre->magic != CBUF_MAGIC) {
-      // VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
+      VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
       return false;
     }
     if (pre->hash != member->hash()) {
-      // VLOG_ASSERT(false,
-      //             "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
-      //             pre->hash);
+      VLOG_ASSERT(false, "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
+                  pre->hash);
       return false;
     }
     if (pre->size() == 0) {
-      // VLOG_ASSERT(false, "Expected size to be non-zero");
+      VLOG_ASSERT(false, "Expected size to be non-zero");
       return false;
     }
 

--- a/ulog/src/cbuf_readerbase.cpp
+++ b/ulog/src/cbuf_readerbase.cpp
@@ -55,7 +55,7 @@ bool CBufReaderBase::computeNextSi() {
       auto msize = si->cis->get_next_size();
       auto nhash = si->cis->get_next_hash();
       fprintf(stderr,
-              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: %zX) [FileSize %zu, "
+              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: %llX) [FileSize %zu, "
               "Offset "
               "%zu], this indicates a corrupted ulog. Trying to recover...\n",
               si->filename.c_str(), msize, nhash, si->cis->get_filesize(), si->cis->get_current_offset());

--- a/ulog/src/cbuf_readerbase.cpp
+++ b/ulog/src/cbuf_readerbase.cpp
@@ -1,15 +1,10 @@
 #include "cbuf_readerbase.h"
 
+#include <filesystem>
+
 #include "vlog.h"
 
-#if (defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE > 7)) || \
-    (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION > 10000))
-#include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 // returns true if time t is within our range
 bool CBufReaderBase::is_valid_early(double t) const noexcept {

--- a/ulog/src/cbuf_readerbase.cpp
+++ b/ulog/src/cbuf_readerbase.cpp
@@ -1,8 +1,9 @@
 #include "cbuf_readerbase.h"
+#include "ulogger.h"
 
 #include <filesystem>
 
-#include "vlog.h"
+#include <vlog.h>
 
 namespace fs = std::filesystem;
 
@@ -50,9 +51,8 @@ bool CBufReaderBase::computeNextSi() {
       auto msize = si->cis->get_next_size();
       auto nhash = si->cis->get_next_hash();
       fprintf(stderr,
-              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: %llX) [FileSize %zu, "
-              "Offset "
-              "%zu], this indicates a corrupted ulog. Trying to recover...\n",
+              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: " U64_FORMAT_HEX
+              ") [FileSize %zu, Offset %zu], this indicates a corrupted ulog. Trying to recover...\n",
               si->filename.c_str(), msize, nhash, si->cis->get_filesize(), si->cis->get_current_offset());
       auto off = si->cis->get_current_offset();
       if (si->cis->skip_corrupted()) {

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -184,7 +184,7 @@ bool cbuf_ostream::merge_packet(cbuf_istream* cis, const std::vector<std::string
     }
   } else {
     if (dictionary.count(hash) == 0) {
-      fprintf(stderr, "processing packet with hash 0x%lX does not have metadata\n", hash);
+      fprintf(stderr, "processing packet with hash 0x%llX does not have metadata\n", hash);
     }
   }
 

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -334,7 +334,11 @@ bool cbuf_istream::open_file(const char* fname) {
   struct stat st;
   stat(fname, &st);
   filesize = st.st_size;
-  memmap_ptr = (unsigned char*)mmap(nullptr, filesize, PROT_READ, MAP_PRIVATE | MAP_POPULATE, stream, 0);
+  int flags = MAP_PRIVATE;
+#if defined(__linux__)
+    flags |= MAP_POPULATE;
+#endif
+  memmap_ptr = (unsigned char*)mmap(nullptr, filesize, PROT_READ, flags, stream, 0);
   if (memmap_ptr == MAP_FAILED) {
     return false;
   }

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -336,7 +336,7 @@ bool cbuf_istream::open_file(const char* fname) {
   filesize = st.st_size;
   int flags = MAP_PRIVATE;
 #if defined(__linux__)
-    flags |= MAP_POPULATE;
+  flags |= MAP_POPULATE;
 #endif
   memmap_ptr = (unsigned char*)mmap(nullptr, filesize, PROT_READ, flags, stream, 0);
   if (memmap_ptr == MAP_FAILED) {

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -31,7 +31,11 @@ double cbuf_ostream::now() const { return ::now(); }
 
 ssize_t cbuf_ostream::file_offset() const {
   if (stream < 0) return -1;
+#if defined(__linux__)
   return lseek64(stream, 0, SEEK_CUR);
+#else
+  return lseek(stream, 0, SEEK_CUR);
+#endif
 }
 
 int cbuf_ostream::serialize_metadata(const char* msg_meta, uint64_t hash, const char* msg_name) {

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -1,4 +1,5 @@
 #include "cbuf_stream.h"
+#include "ulogger.h"
 
 #include <assert.h>
 #include <fcntl.h>
@@ -8,7 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "cbuf_preamble.h"
+#include <cbuf_preamble.h>
 
 static double now() {
   struct timespec ts;
@@ -184,7 +185,7 @@ bool cbuf_ostream::merge_packet(cbuf_istream* cis, const std::vector<std::string
     }
   } else {
     if (dictionary.count(hash) == 0) {
-      fprintf(stderr, "processing packet with hash 0x%llX does not have metadata\n", hash);
+      fprintf(stderr, "processing packet with hash 0x" U64_FORMAT_HEX " does not have metadata\n", hash);
     }
   }
 

--- a/ulog/src/ulogger.cpp
+++ b/ulog/src/ulogger.cpp
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <streambuf>
@@ -21,14 +22,7 @@ static std::mutex g_ulogger_mutex;
 static bool initialized = false;
 static ULogger* g_ulogger = nullptr;
 
-#if (defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE > 7)) || \
-    (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION > 10000))
-#include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 int ULogger::getOrMakeTopicVariant(const uint64_t& message_hash, const uint64_t& topic_name_hash) {
   // get the vector for the give message hash

--- a/ulog/src/ulogger.cpp
+++ b/ulog/src/ulogger.cpp
@@ -87,7 +87,11 @@ extern char* __progname;
 static void name_thread() {
   char thread_name[16] = {};
   snprintf(thread_name, sizeof(thread_name), "ulog_%s", __progname);
+#if defined(__APPLE__)
+  pthread_setname_np(thread_name);
+#else
   pthread_setname_np(pthread_self(), thread_name);
+#endif
 }
 
 double ULogger::time_now() {

--- a/ulog/src/ulogger.cpp
+++ b/ulog/src/ulogger.cpp
@@ -1,6 +1,5 @@
 #include "ulogger.h"
 
-#include <linux/limits.h>
 #include <memory.h>
 #include <pthread.h>
 #include <sys/stat.h>
@@ -10,6 +9,10 @@
 #include <mutex>
 #include <streambuf>
 #include <unordered_map>
+
+#if defined(__linux__)
+#include <linux/limits.h>
+#endif
 
 #include "vlog.h"
 


### PR DESCRIPTION
- Remove shallow clone in FetchDependency (referenced gtest commit is no longer HEAD)
- Portable format strings for 64-bit types
- Ignore function type cast warnings in Python binding code
- Conditionally include linux/limits.h
- Fix pthread_setname_np() call on MacOS
- Fix lseek64() on non-Linux
- Only set MAP_POPULATE mmap() flag on Linux
- Ignore unaligned-access warning in generated structs
- Dead code removal to fix compiler errors
- Replace canonicalize_file_name() with cross-platform implementation
- Disable HJSON tests when building without HJSON
- Fix warning disable pragmas on non-clang compilers
- Fix designated initializers in pycbuf bindings
- Write to a temporary directory during unit testing
- Add CI for Linux and MacOS