### PR TITLE
Remove vlog dependency from pycbuf and ulog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
           make
       # Run tests
       - name: Test
@@ -46,7 +46,7 @@ jobs:
   #       run: |
   #         mkdir build
   #         cd build
-  #         cmake ..
+  #         cmake -DCMAKE_BUILD_TYPE=Debug ..
   #         cmake --build . --config Release
   #     # Run tests
   #     - name: Test
@@ -68,7 +68,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
           make
       # Run tests
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install CMake
-      - name: Install CMake, libelf, libdwarf
+      - name: Install CMake
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libelf-dev libdwarf-dev
+          sudo apt-get install -y cmake
       # Clone the repository
       - uses: actions/checkout@v4
       # CMake configure and build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,132 @@
-build
+# Python #######################################################################
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+_skbuild/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# OS generated files
+.DS_Store

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,13 @@
+// -*- jsonc -*-
+{
+  "configurations": [
+    {
+      "name": "default",
+      "includePath": ["${default}", "${workspaceFolder}/include"],
+      "defines": [],
+      "cppStandard": "c++17",
+      "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,7 @@
       "name": "default",
       "includePath": ["${default}", "${workspaceFolder}/include"],
       "defines": [],
-      "cppStandard": "c++17",
+      "cppStandard": "c++20",
       "compileCommands": "${workspaceFolder}/build/compile_commands.json"
     }
   ],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+// -*- jsonc -*-
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-vscode.cpptools",
+    "xaver.clang-format"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "configurations": [
+    {
+      "name": "(lldb) test_parsing",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/test/test_parsing",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}/build",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+// -*- jsonc -*-
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[cpp]": {
+    "editor.defaultFormatter": "xaver.clang-format"
+  },
+  "files.eol": "\n",
+  "C_Cpp.autoAddFileAssociations": false,
+  "cmake.configureOnOpen": false,
+  "cmake.configureOnEdit": false
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@ include(FetchDependency)
 include(FetchContent)
 include(AddTest)
 
-fetch_dependency(vlog "https://github.com/Verdant-Robotics/vlog.git" "main")
-# optional hjson package, if found it exposes more functionality on the CBufParser class
+# Optional hjson package, if found it exposes more functionality on the CBufParser class
 fetch_dependency(hjson "https://github.com/Verdant-Robotics/hjson.git" "main")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,19 +137,12 @@ endif()
 add_library(cbuf_internal INTERFACE)
 target_include_directories(cbuf_internal INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-option(ENABLE_CBUF_TESTS "Enable Tests" OFF)
+option(ENABLE_CBUF_TESTS "Enable Tests" ON)
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-  set(CBUF_MAIN_PROJECT TRUE)
-else()
-  set(CBUF_MAIN_PROJECT FALSE)
-endif()
-
-if(${ENABLE_CBUF_TESTS} OR ${CBUF_MAIN_PROJECT})
+if(${ENABLE_CBUF_TESTS})
   enable_testing()
+  add_subdirectory(test)
 endif()
 
 add_subdirectory(ulog)
-add_subdirectory(test)
-
 add_subdirectory(pycbuf)

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -233,7 +233,7 @@ static bool compute_hash(ast_struct* st, SymbolTable* symtable) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[" U64_FORMAT "] ", elem->array_suffix->size);
+      buf.print("[%" PRIu64 "] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);
@@ -533,7 +533,7 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
   PyType_Spec* spec = (PyType_Spec*)state->pool->alloc(sizeof(PyType_Spec));
   int str_size = strlen(st->name) + 8 + 5;
   char* type_name = (char*)state->pool->alloc(str_size);
-  snprintf(type_name, str_size, "pycbuf.%s_" U64_FORMAT_HEX, st->name, uint64_t((hash & 0x0FFFFULL)));
+  snprintf(type_name, str_size, "pycbuf.%s_%" PRIX64, st->name, uint64_t((hash & 0x0FFFFULL)));
   spec->name = type_name;
   spec->itemsize = 0;
   spec->flags = Py_TPFLAGS_DEFAULT;

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -793,6 +793,8 @@ unsigned int CBufParserPy::FillPyObject(uint64_t hash, const char* st_name, cons
 
   const cbuf_preamble* pre = (const cbuf_preamble*)buffer;
   if (pre->hash != hash) {
+    PyErr_Format(PyExc_ValueError, "Hash mismatch decoding type `%s`, expected %" PRIX64 ", got %" PRIX64,
+                 cbuf_type->name, hash, pre->hash);
     obj = nullptr;
     buffer = nullptr;
     return 0;

--- a/pycbuf/CBufParserPy.cpp
+++ b/pycbuf/CBufParserPy.cpp
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <structmember.h>
-#include <vlog.h>
 
 #include <cmath>
 
@@ -64,7 +63,7 @@ bool process_element_py(const ast_element* elem, const u8*& bin_buffer, size_t& 
       buf_size -= sizeof(val);
       PyObject* innerobj = nullptr;
       if (mdef->type == T_BOOL) {
-        VLOG_ASSERT(sizeof(T) == 1);
+        if (sizeof(T) != 1) return false;
         innerobj = PyBool_FromLong((uint8_t)val);
       } else {
         innerobj = BuildPyObjectFromNumber(val);
@@ -294,7 +293,7 @@ static bool computeSizes(ast_struct* st, SymbolTable* symtable) {
           elem->csize = 4;
         } else {
           auto* inner_st = symtable->find_struct(elem);
-          VLOG_ASSERT(inner_st);
+          if (inner_st == nullptr) return false;
           bool bret = computeSizes(inner_st, symtable);
           if (!bret) return false;
           elem->csize = 8;
@@ -342,22 +341,21 @@ static int ElemTypeToPyCType(ast_element* e, SymbolTable* sym) {
         return T_UINT;
       } else {
         auto* inner_st = sym->find_struct(e);
-        VLOG_ASSERT(inner_st);
+        if (inner_st == nullptr) return 0;
         return T_OBJECT;
       }
     }
   }
-  VLOG_ASSERT(false);
   return 0;
 }
 
 static PyObject* DynamicStr(PyObject* obj) {
   PyObject* mod = PyType_GetModule(obj->ob_type);
   PyCBuf_State* state = pycbufmodule_getstate(mod);
-  VLOG_ASSERT(state);
+  if (state == nullptr) return nullptr;
 
   pycbuf_preamble* pre = (pycbuf_preamble*)obj;
-  VLOG_ASSERT(state->info_map->contains(pre->hash));
+  if (!state->info_map->contains(pre->hash)) return nullptr;
   PyTypeInfo& pyinfo = (*state->info_map)[pre->hash];
 
   u8* byte_ptr = (u8*)obj;
@@ -424,7 +422,7 @@ static PyObject* DynamicStr(PyObject* obj) {
         break;
       }
       default:
-        VLOG_ASSERT(false, "Unsupported type: %d", md->type);
+        return nullptr;
     }
   }
   retstr += "}";
@@ -434,13 +432,11 @@ static PyObject* DynamicStr(PyObject* obj) {
 
 static void DynamicDealloc(PyObject* obj) {
   PyCBuf_State* state = (PyCBuf_State*)PyType_GetModuleState(Py_TYPE(obj));
-  VLOG_ASSERT(state);
+  if (state == nullptr) return;
 
   pycbuf_preamble* pre = (pycbuf_preamble*)obj;
-  VLOG_ASSERT(state->info_map->contains(pre->hash));
+  if (!state->info_map->contains(pre->hash)) return;
   PyTypeInfo& pyinfo = (*state->info_map)[pre->hash];
-
-  vlog_fine(VCAT_PYCBUF, "Dealloc of object %p type %s", (void*)obj, pre->type_name);
 
   u8* byte_ptr = (u8*)obj;
   for (PyMemberDef* md = pyinfo.members; md->name != nullptr; md++) {
@@ -457,14 +453,16 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
   PyTypeObject* pyType = nullptr;
   if (state->info_map->contains(hash)) {
     pyType = (PyTypeObject*)(*state->info_map)[hash].type;
-    VLOG_ASSERT(pyType != nullptr);
-    VLOG_ASSERT(PyType_Check(pyType) != 0);
+    if (pyType == nullptr) return nullptr;
+    if (PyType_Check(pyType) == 0) return nullptr;
     return pyType;
   }
 
   // We did not have a type, we have to create it
-  VLOG_ASSERT(!state->info_map->contains(hash),
-              "We should not have seen this hash, otherwise there should be a type");
+  if (state->info_map->contains(hash)) {
+    // We should not have seen this hash, otherwise there should be a type
+    return nullptr;
+  }
   PyTypeInfo& pyinfo = (*state->info_map)[hash];
   if (!computeSizes(st, sym)) return nullptr;
   //+1
@@ -516,7 +514,7 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
   if (pyType == nullptr) {
     state->info_map->erase(hash);
   } else {
-    VLOG_ASSERT(PyErr_Occurred() == nullptr);
+    if (PyErr_Occurred()) return nullptr;
 
     pyinfo.type = (PyObject*)pyType;
     PyObject* list = PyList_New(st->elements.size());
@@ -525,7 +523,6 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
     }
     Py_INCREF(list);
     pyinfo.list = list;
-    vlog_debug(VCAT_PYCBUF, "Registered type %s on python, spec ptr %p", type_name, (void*)spec);
 
     // The +7 is to skip "pycbuf." prefix
     if (0 == PyModule_AddObject(m, type_name + 7, (PyObject*)pyType)) {
@@ -539,7 +536,6 @@ PyTypeObject* CBufParserPy::GetPyTypeFromCBuf(uint64_t hash, ast_struct* st, PyO
 bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject* m, PyObject*& obj,
                                         PyCBuf_State* state) {
   if (!compute_hash(st, sym)) {
-    VLOG_ASSERT(false);
     obj = nullptr;
     success = false;
     return false;
@@ -547,33 +543,30 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
   // We cannot ensure we have a hash, like for naked structs. Add this code to ensure things and then drop the
   // hash
   if (hash > 0) {
-    VLOG_ASSERT(st->hash_value == hash);
+    if (st->hash_value != hash) {
+      obj = nullptr;
+      success = false;
+      return false;
+    }
   } else {
     hash = st->hash_value;
   }
 
   // Search the module for an object with of the py_type st_name;
   PyTypeObject* pyType = GetPyTypeFromCBuf(hash, st, m, state);
-  if (pyType == nullptr) {
+  if (pyType == nullptr || PyErr_Occurred()) {
     obj = nullptr;
     success = false;
     return false;
   }
 
-  VLOG_ASSERT(PyErr_Occurred() == nullptr);
-
-  vlog_debug(VCAT_PYCBUF, "Got PyType for object %s :  %p", st->name, (void*)pyType);
-
-  //   create a python object of that type (EXTRA: use default values from cbuf)
+  // Create a python object of that type (EXTRA: use default values from cbuf)
   obj = PyObject_CallObject((PyObject*)pyType, nullptr);
   if (obj == nullptr) {
     // This will allow python to create exceptions
     success = false;
     return false;
   }
-
-  VLOG_ASSERT(obj != nullptr, "Could not instantiate python object of type %s", st->name);
-  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p", st->name, (void*)obj);
 
   // Fill the object members
   // All structs have a preamble, skip it
@@ -587,9 +580,13 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->variant = pre->variant();
     pypre->type_name = st->name;
     pypre->source_name = source_cbuf_file_;
-    VLOG_ASSERT(pre->hash == hash,
-                "Hash mismatch decoding type %s, expected " U64_FORMAT_HEX ", got " U64_FORMAT_HEX, st->name,
-                hash, pre->hash);
+    if (pre->hash != hash) {
+      PyErr_Format(PyExc_ValueError,
+                   "Hash mismatch decoding type `%s`, expected " U64_FORMAT_HEX ", got " U64_FORMAT_HEX,
+                   st->name, hash, pre->hash);
+      success = false;
+      return false;
+    }
     u32 sizeof_preamble = sizeof(cbuf_preamble);  // 8 bytes hash, 4 bytes size
     buffer += sizeof_preamble;
     buf_size -= sizeof_preamble;
@@ -602,9 +599,10 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
     pypre->magic = magic_;
   }
 
-  vlog_debug(VCAT_PYCBUF, "Created object from cbuf type %s, pointer %p, hash: " U64_FORMAT_HEX, st->name,
-             (void*)obj, ((pycbuf_preamble*)obj)->hash);
-  VLOG_ASSERT(state->info_map->contains(((pycbuf_preamble*)obj)->hash));
+  if (!state->info_map->contains(((pycbuf_preamble*)obj)->hash)) {
+    success = false;
+    return false;
+  }
 
   PyTypeInfo& pyInfo = (*state->info_map)[hash];
 
@@ -616,7 +614,7 @@ bool CBufParserPy::FillPyObjectInternal(uint64_t hash, ast_struct* st, PyObject*
   for (int elem_idx = 0; elem_idx < st->elements.size(); elem_idx++) {
     // Uncomment this assert to catch things while debugging
     // without it, python will issue an exception users can see
-    // VLOG_ASSERT(PyErr_Occurred() == nullptr);
+    // assert(PyErr_Occurred() == nullptr);
     auto& elem = st->elements[elem_idx];
     if (!success) return false;
     switch (elem->type) {
@@ -757,7 +755,11 @@ unsigned int CBufParserPy::FillPyObject(uint64_t hash, const char* st_name, cons
   }
 
   const cbuf_preamble* pre = (const cbuf_preamble*)buffer;
-  VLOG_ASSERT(pre->hash == hash);
+  if (pre->hash != hash) {
+    obj = nullptr;
+    buffer = nullptr;
+    return 0;
+  }
   current_timestamp_ = pre->packet_timest;
   magic_ = pre->magic;
 

--- a/pycbuf/pycbuf.cpp
+++ b/pycbuf/pycbuf.cpp
@@ -742,7 +742,7 @@ static PyObject* pycbuf_cbufreader_create_impl(PyObject* self, PyObject* args, P
 PyCBuf_State* pycbufmodule_getstate(PyObject* module) {
   void* state = PyModule_GetState(module);
   if (state == nullptr) {
-    PyErr_SetString(PyExc_RuntimeError, "pycbuf module state is NULL");
+    PyErr_SetString(PyExc_RuntimeError, "Cannot find module state");
     return nullptr;
   }
   return (PyCBuf_State*)state;

--- a/src/AstPrinter.cpp
+++ b/src/AstPrinter.cpp
@@ -105,7 +105,7 @@ void AstPrinter::print_elem(ast_element* elem) {
 
   while (ar != nullptr) {
     if (ar->size != 0)
-      buffer->print_no("[" U64_FORMAT "]", ar->size);
+      buffer->print_no("[%" PRIu64 "]", ar->size);
     else
       buffer->print_no("[]");
     ar = ar->next;

--- a/src/AstPrinter.cpp
+++ b/src/AstPrinter.cpp
@@ -56,9 +56,8 @@ static void PrintAstValue(const ast_value* val, StdStringBuffer* buffer) {
       buffer->print_no("%s", val->str_val);
       break;
     default:
-      // TODO(kartikarcot): Need to relay the error to the user somehow
-      printf("[FATAL] Unknown value provided to PrintAstValue!\n");
-      exit(1);
+      assert(false && "Unknown value type in PrintAstValue");
+      break;
   }
 }
 

--- a/src/CBufParser.cpp
+++ b/src/CBufParser.cpp
@@ -796,6 +796,7 @@ bool convert_element_string(const ast_element* elem, const u8*& bin_buffer, size
     }
     if (!dst_elem->is_dynamic_array) {
       check_dst_array = true;
+      dst_array_size = dst_elem->array_suffix->size;
     }
   }
 

--- a/src/CBufParser.cpp
+++ b/src/CBufParser.cpp
@@ -1086,7 +1086,7 @@ bool compute_hash(ast_struct* st, SymbolTable* symtable, Interp* interp) {
   buf.print("%s \n", st->name);
   for (auto* elem : st->elements) {
     if (elem->array_suffix) {
-      buf.print("[" U64_FORMAT "] ", elem->array_suffix->size);
+      buf.print("[%" PRIu64 "] ", elem->array_suffix->size);
     }
     if (elem->type == TYPE_CUSTOM) {
       auto* enm = symtable->find_enum(elem);

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -144,7 +144,7 @@ void CPrinter::helper_print_array_suffix(ast_element* elem) {
                   elem->name);
   } else {
     // plain simple static array
-    buffer->print_no(" " U64_FORMAT ";\n", elem->array_suffix->size);
+    buffer->print_no(" %" PRIu64 ";\n", elem->array_suffix->size);
   }
 }
 
@@ -190,7 +190,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("ret_size += sizeof(uint32_t); // Encode the length of %s in the var num_%s\n",
                           elem->name, elem->name);
           } else {
-            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = %" PRIu64 ";\n", elem->name, elem->array_suffix->size);
           }
           // No need to encode elements on the static array case, we know them already
           buffer->print("for(int %s_index=0; %s_index < int(num_%s); %s_index++) {\n", elem->name, elem->name,
@@ -312,7 +312,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("*reinterpret_cast<uint32_t *>(data) = num_%s;\n", elem->name);
             buffer->print("data += sizeof(uint32_t);\n");
           } else {
-            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = %" PRIu64 ";\n", elem->name, elem->array_suffix->size);
           }  // No need to encode the number of elements on the static array case, we know them already
           buffer->print("for(size_t %s_index=0; %s_index < num_%s; %s_index++) {\n", elem->name, elem->name,
                         elem->name, elem->name);
@@ -495,7 +495,7 @@ void CPrinter::print_net(ast_struct* st) {
             buffer->print("num_%s = *reinterpret_cast<uint32_t *>(data);\n", elem->name);
             buffer->print("data += sizeof(uint32_t);\n");
           } else {  // No need to decode the number of elements on the static array case, we know them already
-            buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
+            buffer->print("uint32_t num_%s = %" PRIu64 ";\n", elem->name, elem->array_suffix->size);
           }
           buffer->print("for(uint32_t i=0; i<num_%s; i++) {\n", elem->name);
           buffer->increase_ident();
@@ -530,7 +530,7 @@ void CPrinter::print_net(ast_struct* st) {
         } else {
           buffer->print("memcpy(this->%s, data, %d*sizeof(int32_t));\n", elem->name,
                         (int)elem->array_suffix->size);
-          buffer->print("data += " U64_FORMAT "*sizeof(int32_t);\n", elem->array_suffix->size);
+          buffer->print("data += %" PRIu64 "*sizeof(int32_t);\n", elem->array_suffix->size);
         }
       } else if (elem->type == TYPE_CUSTOM) {
         if (elem->is_dynamic_array) {
@@ -552,7 +552,7 @@ void CPrinter::print_net(ast_struct* st) {
         } else {  // @warning: what happens here when the encode net size is not the same on each elem?
           buffer->print("memcpy(this->%s, data, %d*this->%s[0].encode_net_size());\n", elem->name,
                         (int)elem->array_suffix->size, elem->name);
-          buffer->print("data += " U64_FORMAT "*this->%s[0].encode_net_size();\n", elem->array_suffix->size,
+          buffer->print("data += %" PRIu64 "*this->%s[0].encode_net_size();\n", elem->array_suffix->size,
                         elem->name);
         }
       } else {
@@ -905,7 +905,7 @@ void CPrinter::print(ast_element* elem) {
   }
   buffer->print("%s", elem->name);
   while (ar != nullptr) {
-    if (ar->size != 0) buffer->print("[" U64_FORMAT "]", ar->size);
+    if (ar->size != 0) buffer->print("[%" PRIu64 "]", ar->size);
     ar = ar->next;
   }
   if (elem->init_value != nullptr) {
@@ -1010,7 +1010,7 @@ void CPrinter::printLoader(ast_element* elem) {
                     elem->name, elem->name);
     } else {
       buffer->print("if (!json[\"%s\"].defined()) break;\n", elem->name);
-      buffer->print("uint32_t num_%s = " U64_FORMAT ";\n", elem->name, elem->array_suffix->size);
+      buffer->print("uint32_t num_%s = %" PRIu64 ";\n", elem->name, elem->array_suffix->size);
       buffer->print("for( int %s_index=0; %s_index < num_%s; %s_index++) {\n", elem->name, elem->name,
                     elem->name, elem->name);
     }

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -78,8 +78,8 @@ static void print_ast_value(const ast_value* val, StdStringBuffer* buffer) {
       break;
     }
     default:
-      printf("[FATAL] [CPrinter::print_ast_value] Unknown value type %d\n", val->valtype);
-      exit(1);
+      assert(false && "Unknown value type in print_ast_value");
+      break;
   }
 }
 
@@ -1250,8 +1250,8 @@ void CPrinter::printLoader(StdStringBuffer* buf, ast_global* top_ast, SymbolTabl
   main_file = nullptr;
 }
 
-void CPrinter::printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<const char*>& incs,
-                            const char* c_name, const char* outfile) {
+bool CPrinter::printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<const char*>& incs,
+                            std::string& error, const char* c_name, const char* outfile) {
   buffer = buf;
 
   buffer->print("%s : %s ", outfile, c_name);
@@ -1266,11 +1266,14 @@ void CPrinter::printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<con
         if (!p.empty()) break;
       }
       if (p.empty()) {
-        fprintf(stderr, "Include file %s could not be found!\n", top_ast->imported_files[i]);
-        exit(-1);
+        error = "Include file " + std::string(top_ast->imported_files[i]) + " could not be found!";
+        return false;
       }
     }
     buffer->print("\\\n  %s ", p.c_str());
   }
   buffer->print("\n");
+
+  error.clear();
+  return true;
 }

--- a/src/CPrinter.h
+++ b/src/CPrinter.h
@@ -35,6 +35,6 @@ public:
   void printLoader(StdStringBuffer* buf, ast_global* top_ast, SymbolTable* symbols, const char* c_name);
 
   // Prints C-style dependencies to be used in a build system
-  void printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<const char*>& incs, const char* c_name,
-                    const char* outfile);
+  bool printDepfile(StdStringBuffer* buf, ast_global* top_ast, Array<const char*>& incs, std::string& error,
+                    const char* c_name, const char* outfile);
 };

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -323,6 +323,7 @@ void Lexer::Error(const char* msg, ...) {
 #pragma clang diagnostic pop
 #endif
   va_end(args);
+  // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
   exit(1);
 }
 
@@ -457,13 +458,11 @@ void Lexer::getNextTokenInternal(Token& tok) {
         }
         if (i >= 1024 - 1) {
           Error("Found string too long to parse\n");
-          exit(1);
         }
         backslash = (c == '\\');
       }
       if (isNewLine(c)) {
         Error("Newlines are not allowed inside a quoted string\n");
-        exit(1);
       }
       s[i++] = 0;
       tok.type = TK_STRING;

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -183,7 +183,7 @@ const char* TokenTypeToCOP(TOKEN_TYPE type) {
       return st.str;
     }
   }
-  assert("We should never be here, using this function wrong");
+  assert(false && "We should never be here, using this function wrong");
   return nullptr;
 }
 

--- a/src/Lexer.h
+++ b/src/Lexer.h
@@ -13,7 +13,7 @@ class Lexer {
   Array<Token> tokens;
   unsigned int token_index;
   void consumeWhiteSpace();
-  void Error(const char* msg, ...);
+  [[noreturn]] void Error(const char* msg, ...);
   void getNextTokenInternal(Token& tok);
   bool parseStringToken(char* input, Token& tok);
   void parseNumber(Token& tok, char c);

--- a/src/cbuf.cpp
+++ b/src/cbuf.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
   if (!parseArgs(args, argc, argv) || args.help) {
     usage();
-    exit(0);
+    exit(args.help ? 0 : -1);
   }
 
   parser.interp = &interp;
@@ -197,7 +197,11 @@ int main(int argc, char** argv) {
     const std::string srcFile = getCanonicalPath(args.srcfile);
     const std::string dstFile = getCanonicalPath(args.outfile);
 
-    printer.printDepfile(&deptext, top_ast, args.incs, srcFile.c_str(), dstFile.c_str());
+    std::string error;
+    if (!printer.printDepfile(&deptext, top_ast, args.incs, error, srcFile.c_str(), dstFile.c_str())) {
+      fprintf(stderr, "%s\n", error.c_str());
+      return -1;
+    }
     FILE* f = fopen(args.depfile, "w");
     if (f == nullptr) {
       fprintf(stderr, "File %s could not be opened for writing\n", args.depfile);

--- a/src/mytypes.h
+++ b/src/mytypes.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <cinttypes>
 #include <inttypes.h>
 #include <stdint.h>
+
+#include <cinttypes>
 
 #if defined(_WINDOWS) || defined(_WIN32)
 #define PLATFORM_WINDOWS
@@ -13,9 +14,6 @@
 #define PLATFORM_MACOS
 #define PLATFORM_POSIX
 #endif
-
-#define U64_FORMAT "%" PRIu64
-#define U64_FORMAT_HEX "%" PRIX64
 
 typedef signed char s8;
 typedef signed short s16;

--- a/test/test_parsing.cpp
+++ b/test/test_parsing.cpp
@@ -9,12 +9,12 @@
 #include "test_utils.h"
 
 // built from samples/image.cbuf
-#include "image.h" 
+#include "image.h"
 #include "image_json.h"
 
 #if defined(HJSON_PRESENT)
 
-// Test FillHjson method. 
+// Test FillHjson method.
 TEST(HJsonParsing, Simple) {
   messages::image img1;
   set_data(img1, 43);
@@ -122,8 +122,6 @@ TEST(CParsing, Simple) {
             0);
   ASSERT_TRUE(compare(img1, img2));
 }
-
-//#pragma clang diagnostic ignored "-Wunused-variable"
 
 TEST(CParsing, Complex) {
   messages::complex_thing th1;

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -2,8 +2,8 @@
 
 void ensure(bool check, const char* str) {
   if (check) return;
-  printf("Test failure, reason: %s\n", str);
-  assert(false && str);
+  fprintf(stderr, "Test failure, reason: %s\n", str);
+  assert(false);
 }
 
 void set_data(messages::image& img, unsigned seed) {

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -66,7 +66,9 @@ bool compare(const messages::complex_thing& a, const messages::complex_thing& b)
   ensure(compare(a.img[2], b.img[2]), "Comparing complex thing img2");
 
   for (unsigned i = 0; i < 5; i++) {
-    ensure(a.names[i] == b.names[i], "Compare complex things names array");
+    std::string errMsg = "Compare complex things names[" + std::to_string(i) + "]: '" + a.names[i] +
+                         "' vs '" + b.names[i] + "'";
+    ensure(a.names[i] == b.names[i], errMsg.c_str());
   }
 
   ensure(a.hard_dynamic.size() == b.hard_dynamic.size(), "Compare sizes of hard_dynamic");

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -3,7 +3,7 @@
 void ensure(bool check, const char* str) {
   if (check) return;
   printf("Test failure, reason: %s\n", str);
-  assert(false);
+  assert(false && str);
 }
 
 void set_data(messages::image& img, unsigned seed) {
@@ -74,6 +74,5 @@ bool compare(const messages::complex_thing& a, const messages::complex_thing& b)
     ensure(a.hard_dynamic[i] == b.hard_dynamic[i], "Comparing hard_dynamic element");
   }
 
-  printf("CBuf test completed successfully, no errors\n");
   return true;
 }

--- a/ulog/CMakeLists.txt
+++ b/ulog/CMakeLists.txt
@@ -8,13 +8,13 @@ build_cbuf(NAME meta_cbuf MSG_FILES cbufmsg/metadata.cbuf)
 add_library(cbuf_stream SHARED src/cbuf_stream.cpp)
 target_include_directories(cbuf_stream PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(cbuf_stream PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/cbufmsg)
-target_link_libraries(cbuf_stream PUBLIC meta_cbuf cbuf_lib cbuf_parse_dynamic vlog pthread)
+target_link_libraries(cbuf_stream PUBLIC meta_cbuf cbuf_lib cbuf_parse_dynamic pthread)
 
 # uloglib is a library for handling ulogger, how we create logs, and cbufreader, the C++
 # Class using templates to have callbacks as we read messages
 add_library(uloglib SHARED src/ulogger.cpp src/cbuf_readerbase.cpp src/cbuf_reader.cpp)
 target_include_directories(uloglib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(uloglib PUBLIC cbuf_stream vlog)
+target_link_libraries(uloglib PUBLIC cbuf_stream)
 
 add_library(ringbufferlib INTERFACE)
 target_include_directories(ringbufferlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/ulog/include/cbuf_reader.h
+++ b/ulog/include/cbuf_reader.h
@@ -71,6 +71,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
@@ -84,6 +85,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -92,6 +94,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -114,6 +117,7 @@ public:
         warned_conversion = true;
       }
     }
+    // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
     return false;
   }
 };
@@ -156,6 +160,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
@@ -171,6 +176,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -179,6 +185,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -190,6 +197,7 @@ public:
         auto fillret = parser->FastConversion(CBufMsg::TYPE_STRING, cis.get_current_ptr(),
                                               cis.get_next_size(), *parserCurrent, CBufMsg::TYPE_STRING,
                                               (unsigned char*)msg, sizeof(CBufMsg));
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         if (fillret == 0) return false;
         msg->preamble.packet_timest = cis.get_next_timestamp();
 
@@ -197,10 +205,12 @@ public:
         return true;
       }
       if (!warned_conversion) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
+    // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
     return false;
   }
 };
@@ -247,6 +257,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
@@ -260,6 +271,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -268,6 +280,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -279,17 +292,19 @@ public:
         auto fillret = parser->FastConversion(CBufMsg::TYPE_STRING, cis.get_current_ptr(),
                                               cis.get_next_size(), *parserCurrent, CBufMsg::TYPE_STRING,
                                               (unsigned char*)msg, sizeof(CBufMsg));
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         if (fillret == 0) return false;
 
         handler(msg);
         return true;
       }
       if (!warned_conversion) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
-
+    // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
     return false;
   }
 };
@@ -332,6 +347,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
@@ -346,6 +362,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -354,6 +371,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -365,6 +383,7 @@ public:
         auto fillret = parser->FastConversion(CBufMsg::TYPE_STRING, cis.get_current_ptr(),
                                               cis.get_next_size(), *parserCurrent, CBufMsg::TYPE_STRING,
                                               (unsigned char*)msg, sizeof(CBufMsg));
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         if (fillret == 0) return false;
 
         // assuming the istream has been instantiated
@@ -376,7 +395,7 @@ public:
         warned_conversion = true;
       }
     }
-
+    // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
     return false;
   }
 };
@@ -545,6 +564,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
@@ -557,6 +577,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -565,6 +586,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
+            // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
             // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
@@ -576,16 +598,19 @@ public:
         auto fillret = parser->FastConversion(CBufMsg::TYPE_STRING, cis.get_current_ptr(),
                                               cis.get_next_size(), *parserCurrent, CBufMsg::TYPE_STRING,
                                               (unsigned char*)msg, sizeof(CBufMsg));
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         if (fillret == 0) return false;
         msg->preamble.packet_timest = cis.get_next_timestamp();
 
         return true;
       }
       if (!warned_conversion) {
+        // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
         // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
+    // TODO(https://github.com/Verdant-Robotics/cbuf/issues/9): Better error handling
     return false;
   }
 

--- a/ulog/include/cbuf_reader.h
+++ b/ulog/include/cbuf_reader.h
@@ -10,7 +10,6 @@
 
 #include "CBufParser.h"
 #include "cbuf_readerbase.h"
-#include "vlog.h"
 
 namespace fs = std::filesystem;
 
@@ -72,7 +71,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
-        vlog_error(VCAT_GENERAL, "Could not deserialize message of type %s", CBufMsg::TYPE_STRING);
+        // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
       (caller->*handler)(msg);
@@ -85,7 +84,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for message %s", CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -93,8 +92,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for current message %s",
-                       CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -112,8 +110,7 @@ public:
         return true;
       }
       if (!warned_conversion) {
-        vlog_error(VCAT_GENERAL, "cbuf version mismatch for message %s but conversion is not allowed",
-                   CBufMsg::TYPE_STRING);
+        // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
@@ -159,11 +156,11 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
-        vlog_error(VCAT_GENERAL, "Could not deserialize message of type %s", CBufMsg::TYPE_STRING);
+        // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
-      // assuming the istream has been instantiated
 
+      // Assuming the istream has been instantiated
       (caller->*handler)(msg, fs::path(cis.filename()).filename());
       return true;
     }
@@ -174,7 +171,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for message %s", CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -182,8 +179,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for current message %s",
-                       CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -201,8 +197,7 @@ public:
         return true;
       }
       if (!warned_conversion) {
-        vlog_error(VCAT_GENERAL, "cbuf version mismatch for message %s but conversion is not allowed",
-                   CBufMsg::TYPE_STRING);
+        // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
@@ -252,7 +247,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
-        vlog_error(VCAT_GENERAL, "Could not deserialize message of type %s", CBufMsg::TYPE_STRING);
+        // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
       handler(msg);
@@ -265,7 +260,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for message %s", CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -273,8 +268,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for current message %s",
-                       CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -291,8 +285,7 @@ public:
         return true;
       }
       if (!warned_conversion) {
-        vlog_error(VCAT_GENERAL, "Version mismatch for message %s but conversion is not allowed",
-                   CBufMsg::TYPE_STRING);
+        // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
@@ -339,7 +332,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
-        vlog_error(VCAT_GENERAL, "Could not deserialize message of type %s", CBufMsg::TYPE_STRING);
+        // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
       // assuming the istream has been instantiated
@@ -353,7 +346,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for message %s", CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -361,8 +354,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for current message %s",
-                       CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -380,8 +372,7 @@ public:
         return true;
       }
       if (!warned_conversion) {
-        vlog_error(VCAT_GENERAL, "Version mismatch for message %s but conversion is not allowed",
-                   CBufMsg::TYPE_STRING);
+        // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }
@@ -402,17 +393,10 @@ public:
       : CBufReaderBase(options) {}
 
   [[deprecated]] void setRoleFilter(const std::string& filter) {
-    vlog_warning(VCAT_GENERAL,
-                 "This function is depracated. Please update your code. Read this document: "
-                 "https://drive.google.com/file/d/1G6PejUiUGKf_utZxq0UbfUb4kBC-OK3H/view?usp=sharing");
+    error_string_ =
+        "setRoleFilter is deprecated. Please update your code to handle or ignore messages in each handler "
+        "callback";
     source_filters_.push_back(filter);
-  }
-  [[deprecated]] std::string getRoleFilter() const {
-    vlog_warning(VCAT_GENERAL,
-                 "This function is depracated. Please update your code. Read this document: "
-                 "https://drive.google.com/file/d/1G6PejUiUGKf_utZxq0UbfUb4kBC-OK3H/view?usp=sharing");
-    if (source_filters_.empty()) return "";
-    return source_filters_.front();
   }
 
   bool addHandler(const std::string& msg_type, std::shared_ptr<CBufHandlerBase> handler) {
@@ -477,8 +461,10 @@ public:
     // check if the topic name for this message has a namespace
 
     auto msize = next_cis->get_next_size();
-    VLOG_ASSERT(msize != 0 && next_cis->check_next_preamble(),
-                "All corrupted cbuf issues should be handled on computeNextSi");
+    if (msize == 0 || !next_cis->check_next_preamble()) {
+      error_string_ = "All corrupted cbuf issues should be handled on computeNextSi";
+      return false;
+    }
 
     if (use_cis_callback_) {
       cis_callback_(next_cis);
@@ -559,7 +545,7 @@ public:
     if (hash == CBufMsg::TYPE_HASH) {
       bool ret = cis.deserialize(msg);
       if (!ret) {
-        vlog_error(VCAT_GENERAL, "Could not deserialize message of type %s", CBufMsg::TYPE_STRING);
+        // Could not deserialize message of type `CBufMsg::TYPE_STRING`
         return false;
       }
       return true;
@@ -571,7 +557,7 @@ public:
         if (parser == nullptr) {
           parser = new CBufParser();
           if (!parser->ParseMetadata(cis.get_meta_string_for_hash(hash), CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for message %s", CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -579,8 +565,7 @@ public:
         if (parserCurrent == nullptr) {
           parserCurrent = new CBufParser();
           if (!parserCurrent->ParseMetadata(CBufMsg::cbuf_string, CBufMsg::TYPE_STRING)) {
-            vlog_error(VCAT_GENERAL, "metadata could not be parsed for current message %s",
-                       CBufMsg::TYPE_STRING);
+            // Metadata could not be parsed for current message `CBufMsg::TYPE_STRING`
             return false;
           }
         }
@@ -597,8 +582,7 @@ public:
         return true;
       }
       if (!warned_conversion) {
-        vlog_error(VCAT_GENERAL, "cbuf version mismatch for message %s but conversion is not allowed",
-                   CBufMsg::TYPE_STRING);
+        // cbuf version mismatch for message `CBufMsg::TYPE_STRING` and conversion is not allowed
         warned_conversion = true;
       }
     }

--- a/ulog/include/ulogger.h
+++ b/ulog/include/ulogger.h
@@ -13,9 +13,6 @@
 #include "cbuf_stream.h"
 #include "ringbuffer.h"
 
-#define U64_FORMAT "%" PRIu64
-#define U64_FORMAT_HEX "%" PRIX64
-
 // Ulogger is a singleton class to log to a file, using cbuf serialization.
 // Example usage:
 //   ULogger::getULogger()->setLogPath(path);

--- a/ulog/include/ulogger.h
+++ b/ulog/include/ulogger.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vlog.h>
-
 #include <atomic>
 #include <cinttypes>
 #include <climits>
@@ -36,6 +34,7 @@ class ULogger {
   std::function<void(const std::string&)> file_close_callback_;
   std::function<void(const std::string&)> file_open_callback_;
   std::function<void(const void*, size_t)> file_write_callback_;
+  std::function<void(const std::string&)> error_callback_;
 
   // this is the folder where all the log files go to
   std::string outputdir;
@@ -44,9 +43,8 @@ class ULogger {
   std::string ulogfilename;
 
   uint64_t current_file_size = 0;
-  uint32_t file_check_count = 0;
 
-  bool initialize();
+  void initialize();
   cbuf_ostream cos;
   bool quit_thread;
   bool logging_enabled = true;
@@ -60,6 +58,8 @@ class ULogger {
   void endLoggingThread();
 
   double time_now();
+
+  void reportError(const std::string& error);
 
 public:
   std::string getCurrentUlogPath();
@@ -83,6 +83,7 @@ public:
   auto getFileWriteCallback() { return file_write_callback_; }
   void setFileOpenCallback(std::function<void(const std::string&)> cb) { file_open_callback_ = cb; }
   void resetFileCallbacks();
+  void setErrorCallback(std::function<void(const std::string&)> cb) { error_callback_ = cb; }
 
   // gets a topic variant if it exists or adds one and then gets the variant if it does not exist
   int getOrMakeTopicVariant(const uint64_t& message_hash, const uint64_t& topic_name_hash);
@@ -120,16 +121,17 @@ public:
 
     cbuf_preamble* pre = &member->preamble;
     if (pre->magic != CBUF_MAGIC) {
-      VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
+      reportError("Expected magic to be " + std::to_string(CBUF_MAGIC) + ", but it is " +
+                  std::to_string(pre->magic));
       return false;
     }
     if (pre->hash != member->hash()) {
-      VLOG_ASSERT(false, "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
-                  pre->hash);
+      reportError("Expected hash to be " + std::to_string(member->hash()) + ", but it is " +
+                  std::to_string(pre->hash));
       return false;
     }
     if (pre->size() == 0) {
-      VLOG_ASSERT(false, "Expected size to be non-zero");
+      reportError("Expected size to be non-zero");
       return false;
     }
 
@@ -139,13 +141,13 @@ public:
     if (member->supports_compact()) {
       if (!member->encode_net(ringbuffer_mem, stsize)) {
         ringbuffer.populate(buffer_handle);
-        VLOG_ASSERT(false, "Encode net failed for message : %s ", member->TYPE_STRING);
+        reportError("encode_net() failed for message " + std::string(member->TYPE_STRING));
         return false;
       }
     } else {
       if (!member->encode(ringbuffer_mem, stsize)) {
         ringbuffer.populate(buffer_handle);
-        VLOG_ASSERT(false, "Encode failed for message : %s ", member->TYPE_STRING);
+        reportError("encode() failed for message " + std::string(member->TYPE_STRING));
         return false;
       }
     }
@@ -153,16 +155,17 @@ public:
     // Check again
     pre = (cbuf_preamble*)ringbuffer_mem;
     if (pre->magic != CBUF_MAGIC) {
-      VLOG_ASSERT(false, "Expected magic to be %X, but it is %X", CBUF_MAGIC, pre->magic);
+      reportError("Expected magic to be " + std::to_string(CBUF_MAGIC) + ", but it is " +
+                  std::to_string(pre->magic));
       return false;
     }
     if (pre->hash != member->hash()) {
-      VLOG_ASSERT(false, "Expected hash to be " U64_FORMAT_HEX ", but it is " U64_FORMAT_HEX, member->hash(),
-                  pre->hash);
+      reportError("Expected hash to be " + std::to_string(member->hash()) + ", but it is " +
+                  std::to_string(pre->hash));
       return false;
     }
     if (pre->size() == 0) {
-      VLOG_ASSERT(false, "Expected size to be non-zero");
+      reportError("Expected size to be non-zero");
       return false;
     }
 

--- a/ulog/src/cbuf_reader.cpp
+++ b/ulog/src/cbuf_reader.cpp
@@ -144,8 +144,10 @@ bool CBufReaderWindow::processGetters() {
   // check if the topic name for this message has a namespace
 
   auto msize = next_cis->get_next_size();
-  VLOG_ASSERT(msize != 0 && next_cis->check_next_preamble(),
-              "All corrupted cbuf issues should be handled on computeNextSi");
+  if (msize == 0 || !next_cis->check_next_preamble()) {
+    error_string_ = "All corrupted cbuf issues should be handled on computeNextSi";
+    return false;
+  }
 
   if ((is_external_ || isCorrectBox()) && info_getters_map.count(str) > 0) {
     auto& handler = info_getters_map[str];
@@ -167,8 +169,10 @@ bool CBufReaderWindow::processMessage() {
   // check if the topic name for this message has a namespace
 
   auto msize = next_cis->get_next_size();
-  VLOG_ASSERT(msize != 0 && next_cis->check_next_preamble(),
-              "All corrupted cbuf issues should be handled on computeNextSi");
+  if (msize == 0 || !next_cis->check_next_preamble()) {
+    error_string_ = "All corrupted cbuf issues should be handled on computeNextSi";
+    return false;
+  }
 
   if ((is_external_ || isCorrectBox()) && msg_map.count(str) > 0) {
     for (auto& handler : msg_map[str]) {
@@ -198,8 +202,10 @@ bool CBufReaderWindow::processSilently() {
   // check if the topic name for this message has a namespace
 
   auto msize = next_cis->get_next_size();
-  VLOG_ASSERT(msize != 0 && next_cis->check_next_preamble(),
-              "All corrupted cbuf issues should be handled on computeNextSi");
+  if (msize == 0 || !next_cis->check_next_preamble()) {
+    error_string_ = "All corrupted cbuf issues should be handled on computeNextSi";
+    return false;
+  }
 
   if ((is_external_ || isCorrectBox()) && info_getters_map.count(str) > 0) {
     auto& handler = info_getters_map[str];

--- a/ulog/src/cbuf_readerbase.cpp
+++ b/ulog/src/cbuf_readerbase.cpp
@@ -3,8 +3,6 @@
 
 #include <filesystem>
 
-#include <vlog.h>
-
 namespace fs = std::filesystem;
 
 // returns true if time t is within our range
@@ -81,16 +79,11 @@ bool CBufReaderBase::computeNextSi() {
   }
 
   // Find earliest packet
-  StreamInfo* prev_si = next_si;
   next_si = input_streams[0];
   for (auto si : input_streams) {
     if (si->packet_time < next_si->packet_time) {
       next_si = si;
     }
-  }
-
-  if (next_si != prev_si) {
-    vlog_fine(VCAT_GENERAL, "[cbuf_reader] ************** %s ************", next_si->filename.c_str());
   }
 
   if (next_si->cis->empty() || !is_valid_late(next_si->packet_time)) {
@@ -105,7 +98,6 @@ bool CBufReaderBase::computeNextSi() {
 bool CBufReaderBase::openUlog(bool error_ok) {
   if (!fs::exists(ulog_path_)) {
     error_string_ = "Could not find ulog path " + ulog_path_;
-    vlog_error(VCAT_GENERAL, "%s", error_string_.c_str());
     return false;
   }
   for (const auto& f : fs::directory_iterator(ulog_path_)) {
@@ -125,7 +117,6 @@ bool CBufReaderBase::openUlog(bool error_ok) {
           continue;
         }
       }
-      vlog_fine(VCAT_GENERAL, "Found cbuf file: %s", f.path().c_str());
       // this is a cb file, open it
       StreamInfo* si = new StreamInfo;
       si->cis = new cbuf_istream();
@@ -136,9 +127,6 @@ bool CBufReaderBase::openUlog(bool error_ok) {
         input_streams.push_back(si);
       } else {
         error_string_ = "Could not open file " + fname + " for reading.";
-        if (!error_ok) {
-          vlog_error(VCAT_GENERAL, "%s", error_string_.c_str());
-        }
         delete si;
         if (!options_.try_recovery) {
           error_string_ +=
@@ -151,7 +139,6 @@ bool CBufReaderBase::openUlog(bool error_ok) {
   if (input_streams.size() == 0) {
     if (!error_ok) {
       error_string_ = "Could not find any 'cb' file on the ulog file " + ulog_path_;
-      vlog_error(VCAT_GENERAL, "%s", error_string_.c_str());
       return false;
     }
   }

--- a/ulog/src/cbuf_readerbase.cpp
+++ b/ulog/src/cbuf_readerbase.cpp
@@ -1,7 +1,8 @@
 #include "cbuf_readerbase.h"
-#include "ulogger.h"
 
 #include <filesystem>
+
+#include "ulogger.h"
 
 namespace fs = std::filesystem;
 
@@ -49,7 +50,7 @@ bool CBufReaderBase::computeNextSi() {
       auto msize = si->cis->get_next_size();
       auto nhash = si->cis->get_next_hash();
       fprintf(stderr,
-              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: " U64_FORMAT_HEX
+              " ** Reading a cbuf message on %s with invalid preamble (size: %u, hash: %" PRIX64
               ") [FileSize %zu, Offset %zu], this indicates a corrupted ulog. Trying to recover...\n",
               si->filename.c_str(), msize, nhash, si->cis->get_filesize(), si->cis->get_current_offset());
       auto off = si->cis->get_current_offset();

--- a/ulog/src/cbuf_stream.cpp
+++ b/ulog/src/cbuf_stream.cpp
@@ -1,7 +1,7 @@
 #include "cbuf_stream.h"
-#include "ulogger.h"
 
 #include <assert.h>
+#include <cbuf_preamble.h>
 #include <fcntl.h>
 #include <metadata.h>
 #include <sys/mman.h>
@@ -9,7 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <cbuf_preamble.h>
+#include "ulogger.h"
 
 static double now() {
   struct timespec ts;
@@ -185,7 +185,7 @@ bool cbuf_ostream::merge_packet(cbuf_istream* cis, const std::vector<std::string
     }
   } else {
     if (dictionary.count(hash) == 0) {
-      fprintf(stderr, "processing packet with hash 0x" U64_FORMAT_HEX " does not have metadata\n", hash);
+      fprintf(stderr, "processing packet with hash 0x%" PRIX64 " does not have metadata\n", hash);
     }
   }
 


### PR DESCRIPTION
This removes the vlog dependency. pycbuf usage of vlog has been replaced by bubbling up Python exceptions, and ulog usage of vlog has been replaced by an error callback in `Ulogger` and setting `error_string_` in `CBufReaderBase`.

Fixes #2

Two other notable removals:
- The free disk space assertion. This was hardcoded to crash the process if the write destination had less than 1GB free. Periodically blocking to make a syscall checking disk usage while writing to disk may force writes to flush to disk, creating periodic write throughput bottlenecks.
- Modifying the `vlog_option_tee_file` global variable inside `ULogger::setLogPath()`. This is not possible anymore with the vlog dependency removed; it should be done by callers of `setLogPath()` (that are using vlog).